### PR TITLE
Values for SetUp and FEN properties of header are reversed

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -388,8 +388,8 @@ var Chess = function(fen) {
     if (history.length > 0) return;
 
     if (fen !== DEFAULT_POSITION) {
-      header['SetUp'] = fen;
-      header['FEN'] = '1';
+      header['SetUp'] = '1';
+      header['FEN'] = fen;
     } else {
       delete header['SetUp'];
       delete header['FEN'];


### PR DESCRIPTION
In the comment for the pgn function, this PGN spec is referenced: http://www.chessclub.com/help/PGN-spec.

In section 9.7 of the PGN spec, it says the SetUp header should have a value of "0" or "1", while the FEN header should have a FEN string.

In update_setup(), the assignments of values for SetUp and FEN are backwards.
