### PR TITLE
Some load_pgn updates

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1477,6 +1477,11 @@ var Chess = function(fen) {
       /* delete header to get the moves */
       var ms = pgn.replace(header_string, '').replace(new RegExp(mask(newline_char), 'g'), ' ');
 
+      /* delete recursive annotation variations */
+      while (/(\([^\(\)]+\))+?/.test(ms)) {
+        ms = ms.replace(/(\([^\(\)]+\))+?/g, '');
+      }
+
       /* delete comments */
       ms = ms.replace(/(\{[^}]+\})+?/g, '');
 

--- a/chess.js
+++ b/chess.js
@@ -1486,7 +1486,7 @@ var Chess = function(fen) {
       ms = ms.replace(/(\{[^}]+\})+?/g, '');
 
       /* delete move numbers */
-      ms = ms.replace(/\d+\./g, '');
+      ms = ms.replace(/\d+\.(\.\.)?/g, '');
 
 
       /* trim and get array of moves */

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -521,6 +521,10 @@ suite("Load PGN", function() {
       '12. Nd5+ Kd8 13. Nxe7 Bxe7 14. Qg4 d6 15. Qf4 Rg8 16. Qxf7 Bxh4+',
       '17. Kd2 Re8 18. Na3 Na6 19. Qh5 Bf6 20. Qxh1 Bxb2 21. Qh4+ Kd7',
       '22. Rb1 Bxa3 23. Qa4+']},
+    {fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2',
+     pgn: [
+      '1. e4 ( 1. d4 { Queen\'s pawn } d5 ( 1... Nf6 ) ) e5'
+    ]}
   ];
 
   var newline_chars = ['\n', '<br />', '\r\n', 'BLAH'];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -524,6 +524,10 @@ suite("Load PGN", function() {
     {fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2',
      pgn: [
       '1. e4 ( 1. d4 { Queen\'s pawn } d5 ( 1... Nf6 ) ) e5'
+    ]},
+    {fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2',
+     pgn: [
+      '1. e4 { King\'s pawn } ( 1. d4 ) 1... e5'
     ]}
   ];
 


### PR DESCRIPTION
The use case of this is to allow loading of more annotated PGNs. For example:
```
1. d4 d5 2. c4 e6 3. e3 Nf6 4. a3 c6 5. Nf3 Bd6 6. cxd5?!
(6. Bd3 O-O 7. O-O dxc4 8. Bxc4 c5 9. Nc3 Nc6 10. dxc5 Bxc5)
6... cxd5 7. Bd3 a6
```