### PR TITLE
Convert fen param to string before split

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -190,7 +190,7 @@ var Chess = function(fen) {
   }
 
   function load(fen) {
-    var tokens = fen.split(/\s+/);
+    var tokens = new String(fen).split(/\s+/);
     var position = tokens[0];
     var square = 0;
     var valid = SYMBOLS + '12345678/';
@@ -255,7 +255,7 @@ var Chess = function(fen) {
     };
 
     /* 1st criterion: 6 space-seperated fields? */
-    var tokens = fen.split(/\s+/);
+    var tokens = new String(fen).split(/\s+/);
     if (tokens.length !== 6) {
       return {valid: false, error_number: 1, error: errors[1]};
     }


### PR DESCRIPTION
Hi, I'm using Chess.js and I think that this little fix will be appreciated

I suggest just to convert the fen parameter to a string before try to split it, to avoid errors when trying to split something that hasn't split method.

Current behavior: 
![screen shot 2014-06-21 at 3 32 33 am](https://cloud.githubusercontent.com/assets/736728/3348055/9e1c57ec-f90e-11e3-9cdc-93bb12b6cb92.png)

With this fix:
![screen shot 2014-06-21 at 3 39 58 am](https://cloud.githubusercontent.com/assets/736728/3348060/e96dee7c-f90e-11e3-860f-53ec290fcdd6.png)

Best