### PR TITLE
Fix handling of multi-char move evaluation symbols

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1336,11 +1336,11 @@ var Chess = function(fen) {
       */
       function move_from_san(move) {
         /* strip off any move decorations: e.g Nf3+?! */
-        var moveReplaced = move.replace(/[+#?!=]/,'');
+        var move_replaced = move.replace(/=/,'').replace(/[+#]?[?!]*$/,'');
         var moves = generate_moves();
         for (var i = 0, len = moves.length; i < len; i++) {
-          if (moveReplaced ==
-              move_to_san(moves[i]).replace(/[+#?!=]/,'')) {
+          if (move_replaced ===
+              move_to_san(moves[i]).replace(/=/,'').replace(/[+#]?[?!]*$/,'')) {
             return moves[i];
           }
         }
@@ -1488,9 +1488,10 @@ var Chess = function(fen) {
       if (typeof move === 'string') {
         /* convert the move string to a move object */
         /* strip off any move decorations: e.g Nf3+?! */
-        var moveReplaced = move.replace(/[+#?!=]/,'');
+        var move_replaced = move.replace(/=/,'').replace(/[+#]?[?!]*$/,'');
         for (var i = 0, len = moves.length; i < len; i++) {
-          if (moveReplaced === move_to_san(moves[i]).replace(/[+#?!=]/,'')) {
+          if (move_replaced ===
+              move_to_san(moves[i]).replace(/=/,'').replace(/[+#]?[?!]*$/,'')) {
             move_obj = moves[i];
             break;
           }

--- a/test/tests.js
+++ b/test/tests.js
@@ -538,6 +538,14 @@ describe("Load PGN", function() {
      expect: true},
     {pgn: ['1. e4 Qxd7 1/2-1/2'],
       expect: false},
+    {pgn: ['1. e4!! e5?! 2. d4?? d5!?'],
+     fen: 'rnbqkbnr/ppp2ppp/8/3pp3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq d6 0 3',
+     expect: true},
+    {pgn: ['1. e4!+'],
+     expect: false},
+    {pgn: ['1.e4 e6 2.d4 d5 3.exd5 c6?? 4.dxe6 Nf6?! 5.exf7+!! Kd7!? 6.Nf3 Bd6 7.f8=N+!! Qxf8'],
+     fen: 'rnb2q1r/pp1k2pp/2pb1n2/8/3P4/5N2/PPP2PPP/RNBQKB1R w KQ - 0 8',
+     expect: true}
   ];
 
   var newline_chars = ['\n', '<br />', '\r\n', 'BLAH'];


### PR DESCRIPTION
Fixes #88. For example, this is a valid PGN string that should be importable by `load_pgn()`:

`1.e4 e6 2.d4 d5 3.exd5 c6?? 4.dxe6 Nf6?!`

Valid symbols here:
https://en.wikipedia.org/wiki/Chess_annotation_symbols#Move_evaluation_symbols