### PR TITLE
Fix pgn loading for black-to-move (ex. 5... Bg7)

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1423,7 +1423,7 @@ var Chess = function(fen) {
       }
 
       /* delete move numbers */
-      ms = ms.replace(/\d+\./g, '');
+      ms = ms.replace(/\d+\.(\.\.)?/g, '');
 
       /* delete ... indicating black to move */
       ms = ms.replace(/\.\.\./g, '');

--- a/test/tests.js
+++ b/test/tests.js
@@ -559,6 +559,11 @@ describe("Load PGN", function() {
       'Nf6 21. Qh3 Bc6 22. Kg1 Qb8 23. Qg3 Nh5 24. Qf2 Bf6 25. Be2 Bxd4',
       '26. Rxd4 Nf6 27. g3) 18. f5 e5'],
      fen: '3q1rk1/1b1rbp1p/p2p1np1/1p2pP2/3BP3/P1NB3Q/1PP3PP/4RR1K w - - 0 19',
+     expect: true},
+    {pgn: [
+      '1. d4 d5 2. Bf4 Nf6 3. e3 g6 4. Nf3 (4. Nc3 Bg7 5. Nf3 O-O 6. Be2 c5)',
+      '4... Bg7 5. h3 { 5. Be2 O-O 6. O-O c5 7. c3 Nc6 } 5... O-O'],
+     fen: 'rnbq1rk1/ppp1ppbp/5np1/3p4/3P1B2/4PN1P/PPP2PP1/RN1QKB1R w KQ - 1 6',
      expect: true}
   ];
 


### PR DESCRIPTION
Typically see this when RAVs or comments are interleaved with the moves after white's move

Example of a valid PGN:
```
1. d4 d5 2. Bf4 Nf6 3. e3 g6 4. Nf3 (4. Nc3 Bg7 5. Nf3 O-O 6. Be2 c5)
4... Bg7 5. h3 { 5. Be2 O-O 6. O-O c5 7. c3 Nc6 } 5... O-O
```