### PR TITLE
Support Loading Arena PGNs

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1433,8 +1433,8 @@ var Chess = function(fen) {
       /* delete move numbers */
       ms = ms.replace(/\d+\.(\.\.)?/g, '');
 
-      /* delete ... indicating black to move */
-      ms = ms.replace(/\.\.\./g, '');
+      /* delete ... or .. indicating black to move */
+      ms = ms.replace(/\.{2,3}/g, '');
 
       /* delete numeric annotation glyphs */
       ms = ms.replace(/\$\d+/g, '');


### PR DESCRIPTION
Arena includes a space between the move number and the extra two dots to indicate black to move.

For example:
1. e4 e5 (1. .. c5) 2. Nf3
