### PR TITLE
Make constants exportable without creating Chess instance

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -33,21 +33,31 @@
  * https://github.com/jhlywa/chess.js/blob/master/LICENSE
  */
 
+var BLACK = 'b';
+var WHITE = 'w';
+
+var EMPTY = -1;
+
+var PAWN = 'p';
+var KNIGHT = 'n';
+var BISHOP = 'b';
+var ROOK = 'r';
+var QUEEN = 'q';
+var KING = 'k';
+
+var FLAGS = {
+  NORMAL: 'n',
+  CAPTURE: 'c',
+  BIG_PAWN: 'b',
+  EP_CAPTURE: 'e',
+  PROMOTION: 'p',
+  KSIDE_CASTLE: 'k',
+  QSIDE_CASTLE: 'q'
+};
+
 var Chess = function(fen) {
 
   /* jshint indent: false */
-
-  var BLACK = 'b';
-  var WHITE = 'w';
-
-  var EMPTY = -1;
-
-  var PAWN = 'p';
-  var KNIGHT = 'n';
-  var BISHOP = 'b';
-  var ROOK = 'r';
-  var QUEEN = 'q';
-  var KING = 'k';
 
   var SYMBOLS = 'pnbrqkPNBRQK';
 
@@ -105,16 +115,6 @@ var Chess = function(fen) {
   ];
 
   var SHIFTS = { p: 0, n: 1, b: 2, r: 3, q: 4, k: 5 };
-
-  var FLAGS = {
-    NORMAL: 'n',
-    CAPTURE: 'c',
-    BIG_PAWN: 'b',
-    EP_CAPTURE: 'e',
-    PROMOTION: 'p',
-    KSIDE_CASTLE: 'k',
-    QSIDE_CASTLE: 'q'
-  };
 
   var BITS = {
     NORMAL: 1,
@@ -1656,6 +1656,22 @@ var Chess = function(fen) {
 
 /* export Chess object if using node or any other CommonJS compatible
  * environment */
-if (typeof exports !== 'undefined') exports.Chess = Chess;
+if (typeof exports !== 'undefined') {
+    exports.Chess = Chess;
+    exports.constants = {
+        BLACK: BLACK,
+        WHITE: WHITE,
+        EMPTY: EMPTY,
+
+        PAWN: PAWN,
+        KNIGHT: KNIGHT,
+        BISHOP: BISHOP,
+        ROOK: ROOK,
+        QUEEN: QUEEN,
+        KING: KING,
+
+        FLAGS: FLAGS,
+    };
+}
 /* export Chess object for any RequireJS compatible environment */
 if (typeof define !== 'undefined') define( function () { return Chess;  });


### PR DESCRIPTION
I would like suggest to make constants part of exports aside from Chess instance
It makes a little sense to make constants part of Chess instance.
For backward compatibility i didn't remove it from instance of Chess, but if you're ok with such change i would remove it from instance itself.

I will need to look-up how to properly export things for RequireJS format.
But for global use i think there might be a need for namespace.

Maybe something like: 
```
var CONSTANTS = {
  WHITE: 'b',
  ....
};
```

What do you think?