### PR TITLE
Less verbose npm script definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uglify-js": "2.4.21"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "minify": "./node_modules/.bin/uglifyjs chess.js -c -m --comments 'license' > chess.min.js"
+    "test": "mocha",
+    "minify": "uglifyjs chess.js -c -m --comments 'license' > chess.min.js"
   }
 }


### PR DESCRIPTION
The directory `./node_modules/.bin` is always on the PATH when one
runs npm scripts, therefore the references to binaries installed
there can be simplified as follows:

Before:

    ./node_modules/.bin/some-executable

After:

    some-executable

Please review.