### PR TITLE
Update all dependencies to their latest released version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "mocha": "3.4.2",
-    "chai": "2.3.0",
+    "chai": "4.0.2",
     "uglify-js": "2.4.21"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "mocha": "3.4.2",
     "chai": "4.0.2",
-    "uglify-js": "2.4.21"
+    "uglify-js": "3.0.24"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   ],
   "devDependencies": {
-    "mocha": "2.2.4",
+    "mocha": "3.4.2",
     "chai": "2.3.0",
     "uglify-js": "2.4.21"
   },


### PR DESCRIPTION
This PR suggests to update the development dependencies of chess.js as follows:

* `mocha` from `v2.2.4` to `v3.4.2`
* `chai` from `v2.3.0` to `v4.0.2`
* `mocha` from `v2.4.21` to `v3.0.24`

The uglified version stays exactly the same.

Please review.
