### PR TITLE
More conventional way to write the first black move of a PGN.

### DIFF
--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -440,7 +440,7 @@ describe("PGN", function() {
     {moves: ['Ba5', 'O-O', 'd6', 'd4'],     // testing a non-starting position
      header: [],
      max_width:20,
-     pgn: '[SetUp "1"]\n[FEN "r1bqk1nr/pppp1ppp/2n5/4p3/1bB1P3/2P2N2/P2P1PPP/RNBQK2R b KQkq - 0 1"]\n\n1. ... Ba5 2. O-O d6\n3. d4',
+     pgn: '[SetUp "1"]\n[FEN "r1bqk1nr/pppp1ppp/2n5/4p3/1bB1P3/2P2N2/P2P1PPP/RNBQK2R b KQkq - 0 1"]\n\n1... Ba5 2. O-O d6\n3. d4',
      starting_position: 'r1bqk1nr/pppp1ppp/2n5/4p3/1bB1P3/2P2N2/P2P1PPP/RNBQK2R b KQkq - 0 1',
      fen: 'r1bqk1nr/ppp2ppp/2np4/b3p3/2BPP3/2P2N2/P4PPP/RNBQ1RK1 b kq d3 0 3'}
     ];

--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -1611,7 +1611,7 @@ describe('Regression Tests', function() {
 
   it('Github Issue #85 (black) - SetUp and FEN should be accepted in load_pgn', function() {
        var chess = new Chess();
-       var pgn = ['[SetUp "1"]', '[FEN "r4r1k/1p4b1/3p3p/5qp1/1RP5/6P1/3NP3/2Q2RKB b KQkq - 0 1"]', "", '1. ... Qc5+'];
+       var pgn = ['[SetUp "1"]', '[FEN "r4r1k/1p4b1/3p3p/5qp1/1RP5/6P1/3NP3/2Q2RKB b KQkq - 0 1"]', "", '1... Qc5+'];
        var result = chess.load_pgn(pgn.join("\n"));
        expect(result).toBe(true);
        expect(chess.fen()).toBe('r4r1k/1p4b1/3p3p/2q3p1/1RP5/6P1/3NP3/2Q2RKB w KQkq - 1 2');
@@ -1630,7 +1630,7 @@ describe('Regression Tests', function() {
     chess.load('4r3/8/2p2PPk/1p6/pP2p1R1/P1B5/2P2K2/3r4 b - - 1 45');
     chess.move('Rf1+');
     var result = chess.pgn();
-    expect(result.match(/(45\. \.\.\. Rf1\+)$/)[0]).toBe('45. ... Rf1+');
+    expect(result.match(/(45\.\.\. Rf1\+)$/)[0]).toBe('45... Rf1+');
   })
 
   it('Github Issue #129 load_pgn() should not clear headers if PGN contains SetUp and FEN tags', function () {

--- a/chess.js
+++ b/chess.js
@@ -1441,9 +1441,9 @@ var Chess = function(fen) {
         move_string = append_comment(move_string)
         var move = reversed_history.pop()
 
-        /* if the position started with black to move, start PGN with 1. ... */
+        /* if the position started with black to move, start PGN with 1... */
         if (!history.length && move.color === 'b') {
-          move_string = move_number + '. ...'
+          move_string = move_number + '...'
         } else if (move.color === 'w') {
           /* store the previous generated move_string if we have one */
           if (move_string.length) {


### PR DESCRIPTION
When writing a PGN game, the standard way to write "Blacks start the game, and the first move number is 2" should better be "2..." instead of writing "2. ...".

This is the choice of most PGN generators, for example, lichess.org.