### PR TITLE
making blank line after header optional

### DIFF
--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -741,6 +741,16 @@ describe("Load PGN", function() {
       expect: true,
       sloppy: true
     },
+
+    // parse should succeed with missing blank line after headers
+    {pgn: [
+      '[Round "1"]',
+      '1. e4 c5 2. Nf3 d6 3. d4 cxd4',
+      ],
+      fen: 'rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4',
+      expect: true,
+      sloppy: true
+    },
   ];
 
   var newline_chars = ['\n', '<br />', '\r\n', 'BLAH'];

--- a/chess.js
+++ b/chess.js
@@ -1580,16 +1580,10 @@ var Chess = function(fen) {
           ? options.newline_char
           : '\r?\n'
 
-      // RegExp to split header. Takes advantage of the fact that header and movetext
-      // will always have a blank line between them (ie, two newline_char's).
-      // With default newline_char, will equal: /^(\[((?:\r?\n)|.)*\])(?:\r?\n){2}/
+      // RegExp to split header.  This assumes that the header is the initial
+      // set of lines which begin with [ and end with ].
       var header_regex = new RegExp(
-        '^(\\[((?:' +
-          mask(newline_char) +
-          ')|.)*\\])' +
-          '(?:' +
-          mask(newline_char) +
-          '){2}'
+        '^((?:\\[.*\\]' + mask(newline_char) + ')+)'
       )
 
       // If no header given, begin with moves.


### PR DESCRIPTION
Greetings, and thank you for the excellent library!  We use it at nextchessmove.com.  A few users have complained about not being able to paste PGN into the app and website, and in all cases thus far it has been because of a lack of a blank line separating the header and movetext sections.

Would you be open to open to updating chess.js to parse malformed PGN of this type?  This is my initial stab at it.  Note that with this change, it parses the malformed PGN regardless of the sloppy setting -- I'm not sure if that's right.