### PR TITLE
Speed up gen moves - ~30% speed up - Test Cases from 6.8s to 4.5s

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -544,7 +544,10 @@ var Chess = function(fen) {
       typeof options !== 'undefined' && 'legal' in options
         ? options.legal
         : true
-
+      var piece_type = typeof options !== 'undefined' && 'piece' in options
+        ? options.piece.toLowerCase()
+        : true
+    
     /* are we generating moves for a single square? */
     if (typeof options !== 'undefined' && 'square' in options) {
       if (options.square in SQUARES) {
@@ -568,7 +571,7 @@ var Chess = function(fen) {
         continue
       }
 
-      if (piece.type === PAWN) {
+      if (piece.type === PAWN && (piece_type===true || piece_type===PAWN)) {
         /* single square, non-capturing */
         var square = i + PAWN_OFFSETS[us][0]
         if (board[square] == null) {
@@ -592,7 +595,7 @@ var Chess = function(fen) {
             add_move(board, moves, i, ep_square, BITS.EP_CAPTURE)
           }
         }
-      } else {
+      } else if(piece_type===true || piece_type===piece.type ) {
         for (var j = 0, len = PIECE_OFFSETS[piece.type].length; j < len; j++) {
           var offset = PIECE_OFFSETS[piece.type][j]
           var square = i
@@ -1137,7 +1140,7 @@ var Chess = function(fen) {
       }
     }
 
-    var moves = generate_moves()
+    var moves = generate_moves({piece: piece ? piece : clean_move.charAt(0)})
     for (var i = 0, len = moves.length; i < len; i++) {
       // try the strict parser first, then the sloppy parser if requested
       // by the user

--- a/chess.js
+++ b/chess.js
@@ -544,7 +544,7 @@ var Chess = function(fen) {
       typeof options !== 'undefined' && 'legal' in options
         ? options.legal
         : true
-      var piece_type = typeof options !== 'undefined' && 'piece' in options
+      var piece_type = typeof options !== 'undefined' && 'piece' in options && typeof options.piece === "string"
         ? options.piece.toLowerCase()
         : true
     
@@ -1139,8 +1139,19 @@ var Chess = function(fen) {
         var promotion = matches[4]
       }
     }
-
-    var moves = generate_moves({piece: piece ? piece : clean_move.charAt(0)})
+    var piece_type=clean_move.charAt(0)
+    if(piece_type >='a' && piece_type<='h') {
+      var matches=clean_move.match(
+        /[a-h]\d.*[a-h]\d/ 
+        )
+      if(matches)  {
+        piece_type=undefined
+      } else {
+        piece_type='p'
+      }
+    }
+  
+    var moves = generate_moves({piece: piece ? piece : piece_type})
     for (var i = 0, len = moves.length; i < len; i++) {
       // try the strict parser first, then the sloppy parser if requested
       // by the user
@@ -1704,7 +1715,7 @@ var Chess = function(fen) {
           continue
         }
         move = move_from_san(moves[half_move], sloppy)
-
+      
         /* move not possible! (don't clear the board to examine to show the
          * latest valid position)
          */

--- a/chess.js
+++ b/chess.js
@@ -622,40 +622,42 @@ var Chess = function(fen) {
     /* check for castling if: a) we're generating all moves, or b) we're doing
      * single square move generation on the king's square
      */
-    if (!single_square || last_sq === kings[us]) {
-      /* king-side castling */
-      if (castling[us] & BITS.KSIDE_CASTLE) {
-        var castling_from = kings[us]
-        var castling_to = castling_from + 2
+    if(piece_type===true || piece_type==='o') {
+      if (!single_square || last_sq === kings[us]) {
+        /* king-side castling */
+        if (castling[us] & BITS.KSIDE_CASTLE) {
+          var castling_from = kings[us]
+          var castling_to = castling_from + 2
 
-        if (
-          board[castling_from + 1] == null &&
-          board[castling_to] == null &&
-          !attacked(them, kings[us]) &&
-          !attacked(them, castling_from + 1) &&
-          !attacked(them, castling_to)
-        ) {
-          add_move(board, moves, kings[us], castling_to, BITS.KSIDE_CASTLE)
+          if (
+            board[castling_from + 1] == null &&
+            board[castling_to] == null &&
+            !attacked(them, kings[us]) &&
+            !attacked(them, castling_from + 1) &&
+            !attacked(them, castling_to)
+          ) {
+            add_move(board, moves, kings[us], castling_to, BITS.KSIDE_CASTLE)
+          }
+        }
+
+        /* queen-side castling */
+        if (castling[us] & BITS.QSIDE_CASTLE) {
+          var castling_from = kings[us]
+          var castling_to = castling_from - 2
+
+          if (
+            board[castling_from - 1] == null &&
+            board[castling_from - 2] == null &&
+            board[castling_from - 3] == null &&
+            !attacked(them, kings[us]) &&
+            !attacked(them, castling_from - 1) &&
+            !attacked(them, castling_to)
+          ) {
+            add_move(board, moves, kings[us], castling_to, BITS.QSIDE_CASTLE)
+          }
         }
       }
-
-      /* queen-side castling */
-      if (castling[us] & BITS.QSIDE_CASTLE) {
-        var castling_from = kings[us]
-        var castling_to = castling_from - 2
-
-        if (
-          board[castling_from - 1] == null &&
-          board[castling_from - 2] == null &&
-          board[castling_from - 3] == null &&
-          !attacked(them, kings[us]) &&
-          !attacked(them, castling_from - 1) &&
-          !attacked(them, castling_to)
-        ) {
-          add_move(board, moves, kings[us], castling_to, BITS.QSIDE_CASTLE)
-        }
-      }
-    }
+  }
 
     /* return all pseudo-legal moves (this includes moves that allow the king
      * to be captured)
@@ -1150,7 +1152,7 @@ var Chess = function(fen) {
         piece_type='p'
       }
     }
-  
+
     var moves = generate_moves({piece: piece ? piece : piece_type})
     for (var i = 0, len = moves.length; i < len; i++) {
       // try the strict parser first, then the sloppy parser if requested


### PR DESCRIPTION
The purpose of this is to speed up the `generate_moves` function within `move_from_san`.  Specifically; if a piece type is supplied then we can significantly speed this up by only checking for valid moves of that piece.  When dealing with a lot of `pgns` like in an opening database of sorts this gives a decently significant speed up.  There is more that can likely be done; but regardless the test cases ran on my machine on master completed in 6.8 seconds and the test cases on this completed in 4.5.