### PR TITLE
Fix sloppy PGN generation

### DIFF
--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -1716,4 +1716,11 @@ describe('Regression Tests', () => {
       expect(chess.history()).toEqual(history)
       expect(chess.header()['Result']).toBe('1/2-1/2')
     });
+  
+  it('Github Issue #286 - pgn should not generate sloppy moves',
+    () => {
+      const chess = new Chess()
+      chess.load_pgn('1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O')
+      expect(chess.pgn()).toBe('1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O')
+    });
 });

--- a/chess.js
+++ b/chess.js
@@ -1530,7 +1530,7 @@ var Chess = function (fen) {
         move_string =
           move_string +
           ' ' +
-          move_to_san(move, generate_moves({ legal: false }))
+          move_to_san(move, generate_moves({ legal: true }))
         make_move(move)
       }
 


### PR DESCRIPTION
```javascript
const c = new Chess();
c.load_pgn('1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O');
c.history().length // === 7
c.pgn(); // === '1. e4 d5 2. Nf3 Nd7 3. Bb5 Ngf6 4. O-O' <-- notice Ngf6
const c2 = new Chess();
c2.load_pgn(c.pgn()); // === false
c2.history().length; // === 5
```

231b4103 switched `sloppy = false` to `generate_moves({ legal: false })` in the PGN generation code, but chess.js's own PGN loader doesn't accept this sloppier notation. My guess is that this was a typo (since the "false" and "true" booleans were swapped when switching "sloppy" out for "legal").

I've included a regression test, which fails in master:
```
  ● Regression Tests › Github Issue #286 - pgn should not generate sloppy moves

    expect(received).toBe(expected) // Object.is equality

    Expected: "1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O"
    Received: "1. e4 d5 2. Nf3 Nd7 3. Bb5 Ngf6 4. O-O"

      1722 |       const chess = new Chess()
      1723 |       chess.load_pgn('1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O')
    > 1724 |       expect(chess.pgn()).toBe('1. e4 d5 2. Nf3 Nd7 3. Bb5 Nf6 4. O-O')
           |                           ^
      1725 |     });
      1726 | });
      1727 |
```

cc @jafayer