### PR TITLE
Fix a bug in validate_fen.

### DIFF
--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -1372,6 +1372,10 @@ describe('Validate FEN', () => {
       error_number: 2,
     },
     {
+      fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 ',
+      error_number: 2,
+    },
+    {
       fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 0',
       error_number: 2,
     },

--- a/chess.js
+++ b/chess.js
@@ -432,12 +432,12 @@ export const Chess = function (fen) {
     }
 
     /* 2nd criterion: move number field is a integer value > 0? */
-    if (isNaN(tokens[5]) || parseInt(tokens[5], 10) <= 0) {
+    if (isNaN(parseInt(tokens[5])) || parseInt(tokens[5], 10) <= 0) {
       return { valid: false, error_number: 2, error: errors[2] }
     }
 
     /* 3rd criterion: half move counter is an integer >= 0? */
-    if (isNaN(tokens[4]) || parseInt(tokens[4], 10) < 0) {
+    if (isNaN(parseInt(tokens[4])) || parseInt(tokens[4], 10) < 0) {
       return { valid: false, error_number: 3, error: errors[3] }
     }
 


### PR DESCRIPTION
When the move number field is empty (trailing space at the end), the validation returned valid since `isNaN('')` is false and `(parseInt('') <= 0)` is `NaN <= 0`, which is false.

Added the new (previously failing) test case.