### PR TITLE
Add a way to pass an object to the Chess constructor

### DIFF
--- a/__tests__/object-constructor.test.ts
+++ b/__tests__/object-constructor.test.ts
@@ -1,310 +1,654 @@
-import { Chess } from '../src/chess'
-
+import { Chess, DEFAULT_POSITION } from '../src/chess'
+import { plainToClass } from'class-transformer'
 const emptyBoard = "8/8/8/8/8/8/8/8 w - - 0 1"
 const mateFen = "rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3"
 const endGameFen = "8/8/8/8/3r4/8/3P4/3K1k2 w - - 0 1"
 const movesArray = ["d3", "Kc2", "Kc1"]
 const drawFen = "7k/8/8/8/8/8/8/K7 w - - 0 1"
 
-const obj = {
-  "_board": [
-      {
-          "type": "r",
-          "color": "b"
-      },
-      {
-          "type": "n",
-          "color": "b"
-      },
-      {
-          "type": "b",
-          "color": "b"
-      },
-      {
-          "type": "q",
-          "color": "b"
-      },
-      {
-          "type": "k",
-          "color": "b"
-      },
-      {
-          "type": "b",
-          "color": "b"
-      },
-      {
-          "type": "n",
-          "color": "b"
-      },
-      {
-          "type": "r",
-          "color": "b"
-      },
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      {
-          "type": "p",
-          "color": "b"
-      },
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      {
-          "type": "p",
-          "color": "w"
-      },
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      {
-          "type": "r",
-          "color": "w"
-      },
-      {
-          "type": "n",
-          "color": "w"
-      },
-      {
-          "type": "b",
-          "color": "w"
-      },
-      {
-          "type": "q",
-          "color": "w"
-      },
-      {
-          "type": "k",
-          "color": "w"
-      },
-      {
-          "type": "b",
-          "color": "w"
-      },
-      {
-          "type": "n",
-          "color": "w"
-      },
-      {
-          "type": "r",
-          "color": "w"
-      },
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
-  ],
-  "_turn": "w",
-  "_header": {},
-  "_kings": {
-      "w": 116,
-      "b": 4
-  },
-  "_epSquare": -1,
-  "_halfMoves": 0,
-  "_moveNumber": 1,
-  "_history": [],
-  "_comments": {},
-  "_castling": {
-      "w": 96,
-      "b": 96
-  }
-}
-
+const Tests = [
+    {
+        fen: DEFAULT_POSITION,
+        chessBoard: plainToClass(Chess, 
+            {"_board": [
+            {
+                "type": "r",
+                "color": "b"
+            },
+            {
+                "type": "n",
+                "color": "b"
+            },
+            {
+                "type": "b",
+                "color": "b"
+            },
+            {
+                "type": "q",
+                "color": "b"
+            },
+            {
+                "type": "k",
+                "color": "b"
+            },
+            {
+                "type": "b",
+                "color": "b"
+            },
+            {
+                "type": "n",
+                "color": "b"
+            },
+            {
+                "type": "r",
+                "color": "b"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "r",
+                "color": "w"
+            },
+            {
+                "type": "n",
+                "color": "w"
+            },
+            {
+                "type": "b",
+                "color": "w"
+            },
+            {
+                "type": "q",
+                "color": "w"
+            },
+            {
+                "type": "k",
+                "color": "w"
+            },
+            {
+                "type": "b",
+                "color": "w"
+            },
+            {
+                "type": "n",
+                "color": "w"
+            },
+            {
+                "type": "r",
+                "color": "w"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "_turn": "w",
+        "_header": {},
+        "_kings": {
+            "w": 116,
+            "b": 4
+        },
+        "_epSquare": -1,
+        "_halfMoves": 0,
+        "_moveNumber": 1,
+        "_history": [],
+        "_comments": {},
+        "_castling": {
+            "w": 96,
+            "b": 96
+        }
+            }
+        )
+    },
+    {
+        fen: 'rnbqkbnr/2pppppp/8/pp6/PP6/8/2PPPPPP/RNBQKBNR w KQkq b6 0 3',
+        chessBoard: plainToClass(Chess, 
+            {"_board": [
+            {
+                "type": "r",
+                "color": "b"
+            },
+            {
+                "type": "n",
+                "color": "b"
+            },
+            {
+                "type": "b",
+                "color": "b"
+            },
+            {
+                "type": "q",
+                "color": "b"
+            },
+            {
+                "type": "k",
+                "color": "b"
+            },
+            {
+                "type": "b",
+                "color": "b"
+            },
+            {
+                "type": "n",
+                "color": "b"
+            },
+            {
+                "type": "r",
+                "color": "b"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "b"
+            },
+            {
+                "type": "p",
+                "color": "b"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            {
+                "type": "p",
+                "color": "w"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                "type": "r",
+                "color": "w"
+            },
+            {
+                "type": "n",
+                "color": "w"
+            },
+            {
+                "type": "b",
+                "color": "w"
+            },
+            {
+                "type": "q",
+                "color": "w"
+            },
+            {
+                "type": "k",
+                "color": "w"
+            },
+            {
+                "type": "b",
+                "color": "w"
+            },
+            {
+                "type": "n",
+                "color": "w"
+            },
+            {
+                "type": "r",
+                "color": "w"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        "_turn": "w",
+        "_header": {
+            "SetUp": "1",
+            "FEN": "rnbqkbnr/1ppppppp/8/p7/PP6/8/2PPPPPP/RNBQKBNR b KQkq b3 0 2"
+        },
+        "_kings": {
+            "b": 4,
+            "w": 116
+        },
+        "_epSquare": 33,
+        "_halfMoves": 0,
+        "_moveNumber": 3,
+        "_history": [
+            {
+                "move": {
+                    "color": "w",
+                    "from": 96,
+                    "to": 64,
+                    "piece": "p",
+                    "captured": undefined,
+                    "promotion": undefined,
+                    "flags": 4
+                },
+                "kings": {
+                    "b": 4,
+                    "w": 116
+                },
+                "turn": "w",
+                "castling": {
+                    "b": 96,
+                    "w": 96
+                },
+                "epSquare": -1,
+                "halfMoves": 0,
+                "moveNumber": 1
+            },
+            {
+                "move": {
+                    "color": "b",
+                    "from": 16,
+                    "to": 48,
+                    "piece": "p",
+                    "captured": undefined,
+                    "promotion": undefined,
+                    "flags": 4
+                },
+                "kings": {
+                    "b": 4,
+                    "w": 116
+                },
+                "turn": "b",
+                "castling": {
+                    "b": 96,
+                    "w": 96
+                },
+                "epSquare": 80,
+                "halfMoves": 0,
+                "moveNumber": 1
+            },
+            {
+                "move": {
+                    "color": "w",
+                    "from": 97,
+                    "to": 65,
+                    "piece": "p",
+                    "captured": undefined,
+                    "promotion": undefined,
+                    "flags": 4
+                },
+                "kings": {
+                    "b": 4,
+                    "w": 116
+                },
+                "turn": "w",
+                "castling": {
+                    "b": 96,
+                    "w": 96
+                },
+                "epSquare": 32,
+                "halfMoves": 0,
+                "moveNumber": 2
+            },
+            {
+                "move": {
+                    "color": "b",
+                    "from": 17,
+                    "to": 49,
+                    "piece": "p",
+                    "captured": undefined,
+                    "promotion": undefined,
+                    "flags": 4
+                },
+                "kings": {
+                    "b": 4,
+                    "w": 116
+                },
+                "turn": "b",
+                "castling": {
+                    "b": 96,
+                    "w": 96
+                },
+                "epSquare": 81,
+                "halfMoves": 0,
+                "moveNumber": 2
+            }
+        ],
+        "_castling": {
+            "b": 96,
+            "w": 96
+        }
+            }
+        )
+    }
+]
+const FENs=[]
 describe("Chess", () => {
-  const board = new Chess();
-  const newBoard = new Chess(obj);
-  it("FEN",()=> {
-    expect(typeof newBoard.fen).toBe("function");
-    expect(newBoard.fen()).toBe(board.fen());
-  });
+    Tests.forEach(({fen, chessBoard}) => {
+        const board = new Chess(fen);
+        const newBoard = new Chess(chessBoard);
+        it("FEN",()=> {
+            expect(typeof newBoard.fen).toBe("function");
+            expect(newBoard.fen()).toBe(board.fen());
+        });
 
-  it("PGN",()=> {
-    expect(typeof newBoard.pgn).toBe("function");
-    expect(newBoard.pgn()).toBe(board.pgn());
-  });
+        it("move",()=> {
+            expect(typeof newBoard.move).toBe("function");
+            expect(newBoard.move('f3')).toStrictEqual(board.move('f3'));
+            expect(newBoard.fen()).toBe(board.fen());
+        });
 
-  it("move",()=> {
-    expect(typeof newBoard.move).toBe("function");
-    expect(newBoard.move('f3')).toStrictEqual(board.move('f3'));
-    expect(newBoard.fen()).toBe(board.fen());
-  });
+        it("isCheck isMate",()=> {
+            expect(typeof newBoard.isCheck).toBe("function");
+            expect(typeof newBoard.isCheckmate).toBe("function");
+            expect(newBoard.move('e5')).toStrictEqual(board.move('e5'));
+            expect(newBoard.move('g4')).toStrictEqual(board.move('g4'));
+            expect(newBoard.isCheck()).toBeFalsy();
+            expect(newBoard.isCheckmate()).toBeFalsy();
+            expect(newBoard.move('Qh4')).toStrictEqual(board.move('Qh4'));
+            expect(newBoard.isCheck()).toBeTruthy();
+            expect(newBoard.isCheckmate()).toBeTruthy();
+            expect(newBoard.fen()).toBe(board.fen());
+        });
 
-  it("isCheck isMate",()=> {
-    expect(typeof newBoard.isCheck).toBe("function");
-    expect(typeof newBoard.isCheckmate).toBe("function");
-    expect(newBoard.move('e5')).toStrictEqual(board.move('e5'));
-    expect(newBoard.move('g4')).toStrictEqual(board.move('g4'));
-    expect(newBoard.isCheck()).toBeFalsy();
-    expect(newBoard.isCheckmate()).toBeFalsy();
-    expect(newBoard.move('Qh4')).toStrictEqual(board.move('Qh4'));
-    expect(newBoard.isCheck()).toBeTruthy();
-    expect(newBoard.isCheckmate()).toBeTruthy();
-    expect(newBoard.fen()).toBe(board.fen());
-  });
+        it("clear",()=> {
+            expect(typeof newBoard.clear).toBe("function");
+            expect(newBoard.clear()).toBe(board.clear());
+            expect(newBoard.fen()).toStrictEqual(emptyBoard);
+        });
 
-  it("clear",()=> {
-    expect(typeof newBoard.clear).toBe("function");
-    expect(newBoard.clear()).toBe(board.clear());
-    expect(newBoard.fen()).toStrictEqual(emptyBoard);
-  });
+        it("load",()=> {
+            expect(typeof newBoard.load).toBe("function");
+            newBoard.load(mateFen);
+            expect(newBoard.isCheckmate()).toBeTruthy();
+            expect(newBoard.fen()).toStrictEqual(mateFen);
+        });
+        
+        it("moves", ()=> {
+            expect(typeof newBoard.moves).toBe("function");
+            newBoard.load(endGameFen);
+            expect(newBoard.moves()).toStrictEqual(movesArray);
+        });
 
-  it("load",()=> {
-    expect(typeof newBoard.load).toBe("function");
-    newBoard.load(mateFen);
-    expect(newBoard.isCheckmate()).toBeTruthy();
-    expect(newBoard.fen()).toStrictEqual(mateFen);
-  });
-  
-  it("moves", ()=> {
-    expect(typeof newBoard.moves).toBe("function");
-    newBoard.load(endGameFen);
-    expect(newBoard.moves()).toStrictEqual(movesArray);
-  });
-
-  it("draw", ()=> {
-    expect(typeof newBoard.isDraw).toBe("function");
-    newBoard.load(drawFen)
-    expect(newBoard.isDraw()).toBeTruthy();
-  });
-
+        it("draw", ()=> {
+            expect(typeof newBoard.isDraw).toBe("function");
+            newBoard.load(drawFen)
+            expect(newBoard.isDraw()).toBeTruthy();
+        });
+    });
 });

--- a/__tests__/object-constructor.test.ts
+++ b/__tests__/object-constructor.test.ts
@@ -1,0 +1,310 @@
+import { Chess } from '../src/chess'
+
+const emptyBoard = "8/8/8/8/8/8/8/8 w - - 0 1"
+const mateFen = "rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3"
+const endGameFen = "8/8/8/8/3r4/8/3P4/3K1k2 w - - 0 1"
+const movesArray = ["d3", "Kc2", "Kc1"]
+const drawFen = "7k/8/8/8/8/8/8/K7 w - - 0 1"
+
+const obj = {
+  "_board": [
+      {
+          "type": "r",
+          "color": "b"
+      },
+      {
+          "type": "n",
+          "color": "b"
+      },
+      {
+          "type": "b",
+          "color": "b"
+      },
+      {
+          "type": "q",
+          "color": "b"
+      },
+      {
+          "type": "k",
+          "color": "b"
+      },
+      {
+          "type": "b",
+          "color": "b"
+      },
+      {
+          "type": "n",
+          "color": "b"
+      },
+      {
+          "type": "r",
+          "color": "b"
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      {
+          "type": "p",
+          "color": "b"
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      {
+          "type": "p",
+          "color": "w"
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      {
+          "type": "r",
+          "color": "w"
+      },
+      {
+          "type": "n",
+          "color": "w"
+      },
+      {
+          "type": "b",
+          "color": "w"
+      },
+      {
+          "type": "q",
+          "color": "w"
+      },
+      {
+          "type": "k",
+          "color": "w"
+      },
+      {
+          "type": "b",
+          "color": "w"
+      },
+      {
+          "type": "n",
+          "color": "w"
+      },
+      {
+          "type": "r",
+          "color": "w"
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+  ],
+  "_turn": "w",
+  "_header": {},
+  "_kings": {
+      "w": 116,
+      "b": 4
+  },
+  "_epSquare": -1,
+  "_halfMoves": 0,
+  "_moveNumber": 1,
+  "_history": [],
+  "_comments": {},
+  "_castling": {
+      "w": 96,
+      "b": 96
+  }
+}
+
+describe("Chess", () => {
+  const board = new Chess();
+  const newBoard = new Chess(obj);
+  it("FEN",()=> {
+    expect(typeof newBoard.fen).toBe("function");
+    expect(newBoard.fen()).toBe(board.fen());
+  });
+
+  it("PGN",()=> {
+    expect(typeof newBoard.pgn).toBe("function");
+    expect(newBoard.pgn()).toBe(board.pgn());
+  });
+
+  it("move",()=> {
+    expect(typeof newBoard.move).toBe("function");
+    expect(newBoard.move('f3')).toStrictEqual(board.move('f3'));
+    expect(newBoard.fen()).toBe(board.fen());
+  });
+
+  it("isCheck isMate",()=> {
+    expect(typeof newBoard.isCheck).toBe("function");
+    expect(typeof newBoard.isCheckmate).toBe("function");
+    expect(newBoard.move('e5')).toStrictEqual(board.move('e5'));
+    expect(newBoard.move('g4')).toStrictEqual(board.move('g4'));
+    expect(newBoard.isCheck()).toBeFalsy();
+    expect(newBoard.isCheckmate()).toBeFalsy();
+    expect(newBoard.move('Qh4')).toStrictEqual(board.move('Qh4'));
+    expect(newBoard.isCheck()).toBeTruthy();
+    expect(newBoard.isCheckmate()).toBeTruthy();
+    expect(newBoard.fen()).toBe(board.fen());
+  });
+
+  it("clear",()=> {
+    expect(typeof newBoard.clear).toBe("function");
+    expect(newBoard.clear()).toBe(board.clear());
+    expect(newBoard.fen()).toStrictEqual(emptyBoard);
+  });
+
+  it("load",()=> {
+    expect(typeof newBoard.load).toBe("function");
+    newBoard.load(mateFen);
+    expect(newBoard.isCheckmate()).toBeTruthy();
+    expect(newBoard.fen()).toStrictEqual(mateFen);
+  });
+  
+  it("moves", ()=> {
+    expect(typeof newBoard.moves).toBe("function");
+    newBoard.load(endGameFen);
+    expect(newBoard.moves()).toStrictEqual(movesArray);
+  });
+
+  it("draw", ()=> {
+    expect(typeof newBoard.isDraw).toBe("function");
+    newBoard.load(drawFen)
+    expect(newBoard.isDraw()).toBeTruthy();
+  });
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
         "@typescript-eslint/parser": "^5.17.0",
+        "class-transformer": "^0.5.1",
         "eslint": "^8.12.0",
         "jest": "^27.0.6",
         "jest-extended": "^2.0.0",
@@ -1961,6 +1962,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
       "dev": true
     },
     "node_modules/cliui": {
@@ -7298,6 +7305,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "dev": true
+    },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
       "dev": true
     },
     "cliui": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,11 @@
     "type": "git",
     "url": "mygitrepo"
   },
-  "author": "",
-  "license": "BSD-2-Clause",
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
+    "class-transformer": "^0.5.1",
     "eslint": "^8.12.0",
     "jest": "^27.0.6",
     "jest-extended": "^2.0.0",

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,12 +500,12 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(fen = DEFAULT_POSITION, obj?:Chess) {
-    if(obj){
-      Object.assign(this, obj);
-      this.load(this.fen());
+  constructor(value:(string | Chess) = DEFAULT_POSITION) {
+    if(typeof value === 'string'){
+      this.load(value);
     }else{
-        this.load(fen);
+      Object.assign(this, value);
+      this.load(this.fen());
     }
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,12 +500,13 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(value:(string | object) = DEFAULT_POSITION) {
+  constructor(value:(string | Chess) = DEFAULT_POSITION) {
     if(typeof value === 'string'){
       this.load(value);
     }else{
       Object.assign(this, value);
       this.load(this.fen());
+      this._history = value._history
     }
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,8 +500,13 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(fen = DEFAULT_POSITION) {
-    this.load(fen)
+  constructor(fen = DEFAULT_POSITION, obj?:Chess) {
+    if(obj){
+      Object.assign(this, obj);
+      this.load(this.fen());
+    }else{
+        this.load(fen);
+    }
   }
 
   clear(keepHeaders = false) {

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,7 +500,7 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(value:(string | Chess) = DEFAULT_POSITION) {
+  constructor(value:(string | object) = DEFAULT_POSITION) {
     if(typeof value === 'string'){
       this.load(value);
     }else{


### PR DESCRIPTION
### How is it useful?
In my case i save a `Chess` instance in my Mongodb Database.
```javascript
mongoose.Schema({
  board: {
     type: Mixed,
     default: new Chess(),
  }
})
```
So, when i need to get this, it is no longer an instance of Chess, it is just an Object.
```javascript
const board = new board(this.findOne(idBoard));
console.log(board instanceof Chess) //false
````
But, now i can pass the object to the constructor and invoke its methods!
```javascript
const newBoard = new Chess(board)
console.log(newBoard instanceof Chess) //true
newBoard.moves() //works
````
