### PR TITLE
New material count feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,10 @@ chess.pgn({ max_width: 5, newline_char: '<br />' })
 // -> '[White "Plunky"]<br />[Black "Plinkie"]<br /><br />1. e4 e5<br />2. Nc3 Nc6'
 ```
 
+### .material()
+
+Returns the pawn values of the material on the board (Q = 9, R = 5, B = 3, N = 3, P = 1) as an object {black: ..., white: ...}.
+
 ### .put(piece, square)
 
 Place a piece on the square where piece is an object with the form

--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -1030,6 +1030,48 @@ describe('Load PGN', () => {
   })
 })
 
+describe('Material Count', () => {
+  const tests = [
+    {
+      description: 'Starting position',
+      fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      expect: { black: 39, white: 39 },
+    },
+    {
+      description: 'No FEN',
+      fen: undefined,
+      expect: { black: 39, white: 39 },
+    },
+    {
+      description: 'Test position 1',
+      fen: '2r1brk1/1R6/2n1p2p/P4p2/3PnP2/2P2N2/4PPBP/R5K1 b - - 0 25',
+      expect: { black: 22, white: 23 },
+    },
+    {
+      description: 'Test position 2',
+      fen: '8/p1br1kpp/1p3p2/8/P3P3/4B1P1/4KP1P/2R5 b - - 0 32',
+      expect: { black: 13, white: 13 },
+    },
+    {
+      description: 'Checkmate on the board',
+      fen: 'rnb1kbnr/pppp1ppp/8/4p3/5PPq/8/PPPPP2P/RNBQKBNR w KQkq - 0 3',
+      expect: { black: 39, white: 39 },
+    },
+    {
+      description: 'Only kings',
+      fen: '8/8/4k3/8/4K3/8/8/8 w - - 0 0',
+      expect: { black: 0, white: 0 },
+    },
+  ]
+  tests.forEach((t) => {
+    it(t.description, () => {
+      const chess = new Chess(t.fen)
+      expect(chess.material().black).toEqual(t.expect.black)
+      expect(chess.material().white).toEqual(t.expect.white)
+    })
+  })
+})
+
 describe('Manipulate Comments', () => {
   it('no comments', () => {
     const chess = new Chess()

--- a/chess.js
+++ b/chess.js
@@ -1921,9 +1921,11 @@ export const Chess = function (fen) {
     clear: function () {
       return clear()
     },
+
     material: function () {
       return material()
     },
+
     put: function (piece, square) {
       return put(piece, square)
     },

--- a/chess.js
+++ b/chess.js
@@ -579,6 +579,50 @@ export const Chess = function (fen) {
     }
   }
 
+  function material() {
+    const fenAsArray = generate_fen().split(' ')
+    const pieces = fenAsArray[0].split('')
+    let black = 0
+    let white = 0
+    for (let i = 0; i < pieces.length; i++) {
+      switch (pieces[i]) {
+        case 'Q':
+          white += 9
+          break
+        case 'q':
+          black += 9
+          break
+        case 'R':
+          white += 5
+          break
+        case 'r':
+          black += 5
+          break
+        case 'B':
+          white += 3
+          break
+        case 'b':
+          black += 3
+          break
+        case 'N':
+          white += 3
+          break
+        case 'n':
+          black += 3
+          break
+        case 'P':
+          white += 1
+          break
+        case 'p':
+          black += 1
+          break
+        default:
+          break
+      }
+    }
+    return { black: black, white: white }
+  }
+
   function get(square) {
     var piece = board[SQUARE_MAP[square]]
     return piece ? { type: piece.type, color: piece.color } : null
@@ -1877,7 +1921,9 @@ export const Chess = function (fen) {
     clear: function () {
       return clear()
     },
-
+    material: function () {
+      return material()
+    },
     put: function (piece, square) {
       return put(piece, square)
     },


### PR DESCRIPTION
I recently used this feature in an application to select interesting positions to analyse and filtering out positions where material was not close to equal without requiring the use of a chess engine. 

Perhaps it would be a useful addition to chess.js? 

This is my first PR so please look it over carefully and I'll be happy to fix anything if you decide this is a feature you want.

PR Includes "material" function, tests, and an updated readme. 

Thanks,
Matt
matthewn1991@gmail.com