### PR TITLE
fix loadPgn() to handle pgn without any moves

### DIFF
--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -36,7 +36,7 @@ describe('Load PGN', () => {
         '[Round "6"]',
         '[White "Kevo1ution"]',
         '[Black "Billy Bob Jr."]',
-        '',
+        '', // extra newlineChar is expected because pgn() function adds it
       ],
       expect: true
     },

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -41,7 +41,7 @@ describe('Load PGN', () => {
       expect: true
     },
     {
-      pgn: [''],
+      pgn: [''], // extra newlineChar is expected because pgn() function adds it
       expect: true
     },
     {

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -29,6 +29,17 @@ describe('Load PGN', () => {
       ],
       expect: true,
     },
+    // GitHub Issue #362 - Load PGN works with no moves
+    {
+      pgn: [
+        '[Event "UrTurn Game Jam"]',
+        '[Round "6"]',
+        '[White "Kevo1ution"]',
+        '[Black "Billy Bob Jr."]',
+        '',
+      ],
+      expect: true
+    },
     {
       fen: '1n1Rkb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2K5 b k - 1 17',
       pgn: [

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -41,6 +41,10 @@ describe('Load PGN', () => {
       expect: true
     },
     {
+      pgn: [''],
+      expect: true
+    },
+    {
       fen: '1n1Rkb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2K5 b k - 1 17',
       pgn: [
         '[Event "Paris"]',

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1528,15 +1528,19 @@ export class Chess {
     pgn = pgn.trim()
 
     // RegExp to split header. Takes advantage of the fact that header and movetext
-    // will always have a blank line between them (ie, two newline_char's).
-    // With default newline_char, will equal: /^(\[((?:\r?\n)|.)*\])(?:\s*\r?\n){2}/
+    // will always have a blank line between them (ie, two newline_char's). Handles
+    // case where movetext is empty by matching newlineChar until end of string is
+    // matched - effectively trimming from the end extra newlineChar.
+    // With default newline_char, will equal: /^(\[((?:\r?\n)|.)*\])((?:\s*\r?\n){2}|(?:\s*\r?\n)*$)/
     const headerRegex = new RegExp(
       '^(\\[((?:' +
         mask(newlineChar) +
         ')|.)*\\])' +
-        '(?:\\s*' +
+        '((?:\\s*' +
         mask(newlineChar) +
-        '){2}'
+        '){2}|(?:\\s*' +
+        mask(newlineChar) +
+        ')*$)'
     )
 
     // If no header given, begin with moves.
@@ -1655,7 +1659,7 @@ export class Chess {
     let moves = ms.trim().split(new RegExp(/\s+/))
 
     /* delete empty entries */
-    moves = moves.join(',').replace(/,,+/g, ',').split(',')
+    moves = moves.filter(move => move !== '')
 
     let result = ''
 


### PR DESCRIPTION
fixes #362 

**What**
- handles empty move text by matching headers when move text is empty and by parsing out moves that are empty strings

**Why**
- loadPgn() should handle a PGN that does not contain any moves and only headers