### PR TITLE
Fix type of Move.from and Move.to

### DIFF
--- a/src/chess.ts
+++ b/src/chess.ts
@@ -79,8 +79,8 @@ interface History {
 
 export type Move = {
   color: Color
-  from: string
-  to: string
+  from: Square
+  to: Square
   piece: PieceSymbol
   captured?: PieceSymbol
   promotion?: PieceSymbol


### PR DESCRIPTION
I think `Move.from` and `Move.to` should be of type `Square` and not `string`.

I run `npm run build`, `npm run lint`, and `npm run test` after the change -- all executed successfully.