### PR TITLE
Fix major esm inconsistency

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "removeComments": false,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2015"
+    "target": "ES2017"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "outDir": "./dist",
     "removeComments": false,
+    "sourceMap": true,
     "strict": true,
     "target": "ES2015"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2015",
     "declaration": true,
+    "esModuleInterop": true,
+    "module": "ES2015",
+    "moduleResolution": "node",
     "outDir": "./dist",
-    "strict": true
+    "removeComments": false,
+    "strict": true,
+    "target": "ES2015"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fix **major** inconsistency in `v1.0.0-beta.2`
NPM package is published as `module` but the file `chess.js` is exported as `commonJs`

The situation in the current stable version (`v0.13.4`) : the package is published as an ESM module (see source here https://www.npmjs.com/package/chess.js/v/0.13.4?activeTab=explore)

In this PR:
- commit ce815a9: restores the `v0.13.4` situation
- commit 7345604: add sourceMap to the npm package (it is a good practice)
- commit 27214ca: transpile in ES2017 instead of ES2015 to publish native async/await (supported from Node >= 8 and [every browser for the past 5 years](https://caniuse.com/async-functions))

@justinfagnani any thoughts?
