### PR TITLE
Make moveNumber accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,16 @@ chess.move('Nge7', { strict: true }) // strict SAN requires Ne7
 // Error: Invalid move: Nge7
 ```
 
+### .moveNumber()
+
+Returns the current move number.
+
+```ts
+chess.load('4r1k1/p1prnpb1/Pp1pq1pp/3Np2P/2P1P3/R4N2/1PP2PP1/3QR1K1 w - - 2 20')
+chess.moveNumber()
+// -> 20
+```
+
 ### .moves({ piece?: Piece, square?: Square, verbose?: Boolean }?)
 
 Returns a list of legal moves from the current position. This function takes an

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -2287,4 +2287,8 @@ export class Chess {
       [QUEEN]: (this._castling[color] & SIDES[QUEEN]) !== 0,
     }
   }
+
+  moveNumber() {
+    return this._moveNumber
+  }
 }


### PR DESCRIPTION
It seems to me that the moveNumber should be accessible in the same way as the current turn. Being part of FEN it can't really be considered a private implementation detail.