### PR TITLE
feat: add support for esm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,33 @@ NPM:
 npm install chess.js
 ```
 
+## Import into your project
+
+### Modern way (ESM)
+
+```js
+import { Chess } from 'chess.js'
+```
+
+If you want to use it in a browser you can import as module like this:
+
+```html
+<script type="module">
+  import { Chess } from 'chess.js'
+</script>
+```
+
+### Old way (CommonJS)
+
+```js
+const { Chess } = require('chess.js')
+```
+
 ## Example Code
 
 The code below plays a random game of chess:
 
-```ts
-import { Chess } from 'chess.js'
-
+```js
 const chess = new Chess()
 
 while (!chess.isGameOver()) {
@@ -221,9 +241,9 @@ chess.get('a6')
 ### .getCastlingRights(color)
 
 Gets the castling rights for the given color. An object is returned which
-indicates whether the right is available or not for both kingside and
-queenside. Note this does not indicate if such a move is legal or not in the
-current position as checks etc. also need to be considered.
+indicates whether the right is available or not for both kingside and queenside.
+Note this does not indicate if such a move is legal or not in the current
+position as checks etc. also need to be considered.
 
 ```ts
 const chess = new Chess()
@@ -792,7 +812,7 @@ square.
 
 ```ts
 // white can't castle kingside but can castle queenside
-chess.setCastlingRights(WHITE, {[chess.KING]: false, [chess.QUEEN]: true})
+chess.setCastlingRights(WHITE, { [chess.KING]: false, [chess.QUEEN]: true })
 ```
 
 ### .setComment(comment)

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name": "chess.js",
   "version": "1.0.0-beta.5",
   "license": "BSD-2-Clause",
-  "main": "dist/chess.js",
-  "types": "dist/chess.d.ts",
+  "main": "dist/cjs/chess.js",
+  "module": "dist/esm/chess.js",
+  "types": "dist/types/chess.d.ts",
   "homepage": "https://github.com/jhlywa/chess.js",
   "author": "Jeff Hlywa <jhlywa@gmail.com>",
   "scripts": {
     "test": "jest",
     "lint": "eslint src/ --ext .ts",
-    "build": "tsc --build",
-    "clean": "tsc --build --clean"
+    "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json",
+    "clean": "rm -rf ./dist"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "esnext"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,11 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "./dist",
     "removeComments": false,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "ESNext"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
With this changes you will offer CommonJS (CJS) for old node code that use `require` and also for modern development based on Ecmascript Modules (ESM) and compatible with client side.

Close #405