### PR TITLE
fix: add check for pawn promotion in validateFen

### DIFF
--- a/__tests__/validate_fen.test.ts
+++ b/__tests__/validate_fen.test.ts
@@ -27,6 +27,16 @@ test.each([
     ok: false,
   },
   {
+    // white pawn on 8th row
+    fen: '3P4/1k2K3/8/8/8/8/8/8 w - - 0 1',
+    ok: false,
+  },
+  {
+    // black pawn on 1st row
+    fen: '8/8/8/8/8/8/1k3K2/3p4 w - - 0 1',
+    ok: false,
+  },
+  {
     fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRw KQkq - 0 1',
     ok: false,
   },

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -403,11 +403,13 @@ export function validateFen(fen: string) {
     }
   }
 
-  // 11th criterion: are any pawns on promotion row?
-  if (rows[0].includes('P') || rows[7].includes('p')) {
+  // 11th criterion: are any pawns on the first or eighth rows?
+  if (
+    Array.from(rows[0] + rows[7]).some((char) => char.toUpperCase() === 'P')
+  ) {
     return {
       ok: false,
-      error: 'Invalid FEN: pawns on promotion row',
+      error: 'Invalid FEN: some pawns are on the edge rows',
     }
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -379,6 +379,7 @@ export function validateFen(fen: string) {
     }
   }
 
+  // 9th criterion: is en-passant square legal?
   if (
     (tokens[3][1] == '3' && tokens[1] == 'w') ||
     (tokens[3][1] == '6' && tokens[1] == 'b')
@@ -386,6 +387,7 @@ export function validateFen(fen: string) {
     return { ok: false, error: 'Invalid FEN: illegal en-passant square' }
   }
 
+  // 10th criterion: does chess position contain exact two kings?
   const kings = [
     { color: 'white', regex: /K/g },
     { color: 'black', regex: /k/g },
@@ -398,6 +400,14 @@ export function validateFen(fen: string) {
 
     if ((tokens[0].match(regex) || []).length > 1) {
       return { ok: false, error: `Invalid FEN: too many ${color} kings` }
+    }
+  }
+
+  // 11th criterion: are any pawns on promotion row?
+  if (rows[0].includes('P') || rows[7].includes('p')) {
+    return {
+      ok: false,
+      error: 'Invalid FEN: pawns on promotion row',
     }
   }
 


### PR DESCRIPTION
If chess position has pawn on the last row, `chess.js` doesn't detect it as invalid fen, and the game continues as usual.

On the record below I've inited new game with fen where there is a pawn on the last row, (I'm playing as white, and blacks are playing random move from `game.moves()`
```
  const chess = new Chess("3P4/1k2K3/8/8/8/8/8/8 w - - 0 1")
```

https://github.com/jhlywa/chess.js/assets/42891870/e65c2315-7c23-46b1-a557-448cb9a7560b

