### PR TITLE
fix readme shield links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # chess.js
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jhlywa/chess.js/node.js.yml)
-![npm](https://img.shields.io/npm/v/chess.js?color=blue)
-![npm](https://img.shields.io/npm/dm/chess.js)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jhlywa/chess.js/node.js.yml)](https://github.com/jhlywa/chess.js/actions)
+[![npm](https://img.shields.io/npm/v/chess.js?color=blue)](https://www.npmjs.com/package/chess.js)
+[![npm](https://img.shields.io/npm/dm/chess.js)](https://www.npmjs.com/package/chess.js)
 
 chess.js is a TypeScript chess library used for chess move
 generation/validation, piece placement/movement, and check/checkmate/stalemate


### PR DESCRIPTION
The readme badges currently don't link to anything (they just link to the the image's URL). I've updated these to link to the relevant URL.