### PR TITLE
fix: changing piece on the kings square with chess.put()

### DIFF
--- a/src/chess.ts
+++ b/src/chess.ts
@@ -808,6 +808,7 @@ export class Chess {
 
     const currentPieceOnSquare = this._board[sq]
 
+    // if one of the kings will be replaced by the piece from args, set the `_kings` respective entry to `EMPTY`
     if (currentPieceOnSquare && currentPieceOnSquare.type === KING) {
       this._kings[currentPieceOnSquare.color] = EMPTY
     }

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -806,6 +806,12 @@ export class Chess {
       return false
     }
 
+    const currentPieceOnSquare = this._board[sq]
+
+    if (currentPieceOnSquare && currentPieceOnSquare.type === KING) {
+      this._kings[currentPieceOnSquare.color] = EMPTY
+    }
+
     this._board[sq] = { type: type as PieceSymbol, color: color as Color }
 
     if (type === KING) {


### PR DESCRIPTION
Hello! I want to make a chessboard, where users can manually set the position they need and  the`chess.put()` and `chess.remove()` methods are superuseful for me. I found a tiny bug, which I can make work with small hack, but anyway it is confusing and will be nice to fix it.

Lets say I want manually swap white king's and white queen's positions.

```
const chess = new Chess()

const status1 = chess.put({ type: 'q', color: 'w' }, 'e1') // true
const status2 = chess.put({ type: 'k', color: 'w' }, 'd1') // false

```


but if I remove white king and only after then put queen and king it works without errors

```
const chess = new Chess()

chess.remove('e1')
const status1 = chess.put({ type: 'q', color: 'w' }, 'e1') // true
const status2 = chess.put({ type: 'k', color: 'w' }, 'd1') // true

```

I can provide more details if it is required. Thank you