### PR TITLE
Use template literals for board position type

### DIFF
--- a/src/chess.ts
+++ b/src/chess.ts
@@ -38,16 +38,13 @@ export const KING = 'k'
 export type Color = 'w' | 'b'
 export type PieceSymbol = 'p' | 'n' | 'b' | 'r' | 'q' | 'k'
 
-// prettier-ignore
-export type Square =
-    'a8' | 'b8' | 'c8' | 'd8' | 'e8' | 'f8' | 'g8' | 'h8' |
-    'a7' | 'b7' | 'c7' | 'd7' | 'e7' | 'f7' | 'g7' | 'h7' |
-    'a6' | 'b6' | 'c6' | 'd6' | 'e6' | 'f6' | 'g6' | 'h6' |
-    'a5' | 'b5' | 'c5' | 'd5' | 'e5' | 'f5' | 'g5' | 'h5' |
-    'a4' | 'b4' | 'c4' | 'd4' | 'e4' | 'f4' | 'g4' | 'h4' |
-    'a3' | 'b3' | 'c3' | 'd3' | 'e3' | 'f3' | 'g3' | 'h3' |
-    'a2' | 'b2' | 'c2' | 'd2' | 'e2' | 'f2' | 'g2' | 'h2' |
-    'a1' | 'b1' | 'c1' | 'd1' | 'e1' | 'f1' | 'g1' | 'h1'
+// To export or not to export? That is the question.
+export type BoardColumn = 'a' | 'b' | 'c' | 'd' | 'e' |'f' | 'g' 'h'
+export type BoardRow = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+
+// A representation for the various positions on the chess board,
+// e.g squares like 'a1' or 'c5'.
+export type Square = `${BoardRow}${BoardColumn}`
 
 export const DEFAULT_POSITION =
   'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'


### PR DESCRIPTION
Was enjoying this library, but found this... weird? type. Typescript template literals can help you keep things DRY.

P.S: I'm committing this directly from Github's code editor thing, which means that it hasn't been properly formatted with Prettier.