### PR TITLE
Add prepare hook to run build when installed as git dependency directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://github.com/jhlywa/chess.js",
   "author": "Jeff Hlywa <jhlywa@gmail.com>",
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json",
     "check": "npm run format:check && npm run lint && npm run test && npm run build",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
### Issue
Currently, adding **chess.js** as a dependency from **npm** works without issue, i.e. `npm install chess.js`. However, adding it as a **git** or **Github** dependency directly using `npm install github:jhlywa/chess.js` (or similar) will cause an import error.

Installing the dependency from a **git** repo directly is required to use commits after the most recent **npm** published version.

### Cause
For example, **Vite** may give: `Failed to resolve entry for package "chess.js". The package may have incorrect main/module/exports specified in its package.json.`
This occurs because the **chess.js** `package.json` specifies paths in the `dist` directory that doesn't exist until `npm run build` is done.

### Solution
This PR adds a `prepare` hook that triggers `npm run build` in the following cases:
> **prepare** (since npm@4.0.0)
> - Runs BEFORE the package is packed, i.e. during npm publish and npm pack
> - Runs on local npm install without any arguments
> - Runs AFTER prepublish, but BEFORE prepublishOnly
> - NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.
> - As of npm@7 these scripts run in the background. To see the output, run with: --foreground-scripts.
> 

_See: **npm** CLI life cycle scripts [documentation](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts)._

This is a tiny change to `package.json`.