### PR TITLE
A couple additional test cases

### DIFF
--- a/__tests__/is-gameover.test.ts
+++ b/__tests__/is-gameover.test.ts
@@ -1,0 +1,16 @@
+import { Chess } from '../src/chess'
+
+test('isGameOver - works - stalemate', () => {
+  const chess = new Chess('8/8/5k2/p4p1p/P4K1P/1r6/8/8 w - - 0 2')
+  expect(chess.isGameOver()).toBe(true)
+})
+
+test('isGameOver - works - checkmate', () => {
+  const chess = new Chess('8/5r2/4K1q1/4p3/3k4/8/8/8 w - - 0 7')
+  expect(chess.isGameOver()).toBe(true)
+})
+
+test('isGameOver - works - insufficient material', () => {
+  const chess = new Chess('k7/8/8/8/8/8/8/7K w - - 0 1')
+  expect(chess.isGameOver()).toBe(true)
+})

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -253,6 +253,34 @@ test('loadPgn - works - FEN and SetUp tag', () => {
   expect(chess.fen()).toEqual(fen)
 })
 
+test('loadPgn - strict - SetUp tag requires FEN tag', () => {
+  const chess = new Chess()
+  const pgn = `
+[White "Paul Morphy"]
+[Black "Duke Karl / Count Isouard"]
+[SetUp "1"]
+
+17.Rd8# 1-0`
+
+  expect(() => chess.loadPgn(pgn, { strict: true })).toThrow(
+    'Invalid PGN: FEN tag must be supplied with SetUp tag',
+  )
+})
+
+test('loadPgn - strict - FEN and SetUp tag', () => {
+  const chess = new Chess()
+  const fen = '1n1Rkb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2K5 b k - 1 17'
+  const pgn = `
+[White "Paul Morphy"]
+[Black "Duke Karl / Count Isouard"]
+[SetUp "1"]
+[FEN "1n2kb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2KR4 w k - 0 17"]
+
+17.Rd8# 1-0`
+  chess.loadPgn(pgn, { strict: true })
+  expect(chess.fen()).toEqual(fen)
+})
+
 test("loadPgn - works - prunes numeric annotation glyphs (NAG's)", () => {
   const chess = new Chess()
   const fen = 'r2r2k1/5pp1/p1p2q2/PpP1p3/1PnbP2p/5R2/2Q1BPPP/2B2RK1 b - - 3 27'

--- a/__tests__/move.test.ts
+++ b/__tests__/move.test.ts
@@ -295,3 +295,17 @@ test('move - works - queenside castling', () => {
     expect(chess.fen()).toEqual(next)
   }
 })
+
+test('move - works - ambiguous capitalization in move notation', () => {
+  /*
+   * Some positions and moves may be ambiguous when using the permissive
+   * parser. For example, in this position: ,
+   * the move b1c3 may be interpreted as Nc3 or B1c3 (a disambiguated bishop
+   * move). In these cases, the permissive parser will default to the most
+   * basic interpretation (which is b1c3 parsing to Nc3).
+   */
+  const chess = new Chess('6k1/8/8/B7/8/8/8/BN4K1 w - - 0 1')
+  const move = chess.move('b1c3')
+  expect(move.san).not.toEqual('B1c3')
+  expect(move.san).toEqual('Nc3')
+})

--- a/__tests__/pgn.test.ts
+++ b/__tests__/pgn.test.ts
@@ -1,4 +1,4 @@
-import { Chess } from '../src/chess'
+import { BLACK, Chess, WHITE } from '../src/chess'
 import { split, fileToString } from './utils'
 
 describe('PGN', () => {
@@ -104,6 +104,43 @@ describe('PGN', () => {
     expect(chess.header()).toEqual(chess2.header())
   })
 
+  test('pgn - works - begins on correct turn - black', () => {
+    const chess = new Chess()
+    chess.loadPgn('1. e4')
+    expect(chess.turn()).toBe(BLACK)
+  })
+
+  test('pgn - works - begins on correct turn - white', () => {
+    const chess = new Chess()
+    chess.loadPgn('1. e4 e5')
+    expect(chess.turn()).toBe(WHITE)
+  })
+
+  test('pgn - works - begins on correct turn when empty', () => {
+    const chess = new Chess()
+    const pgn = `
+  [White "LichessAborter"]
+  [Black "PoorSap"]
+
+*`
+    chess.loadPgn(pgn)
+    expect(chess.turn()).toBe(WHITE)
+  })
+
+  test('pgn - works - supports removing non-existent header', () => {
+    const chess = new Chess()
+    const pgn = `
+  [White "LichessAborter"]
+  [Black "PoorSap"]
+
+  *`
+
+    chess.loadPgn(pgn)
+
+    const exists = chess.removeHeader('Non-existent')
+    expect(exists).toEqual(false)
+  })
+
   positions.forEach((position, i) => {
     it(`Postion: ${i}`, () => {
       const chess = new Chess()
@@ -119,6 +156,11 @@ describe('PGN', () => {
 
       // verify the fen in the final position
       expect(chess.fen()).toBe(position.fen)
+
+      // verify expected number of moves
+      const expectedMoves =
+        Math.floor(position.moves.split(/\s+/).length / 2) + 1
+      expect(chess.moveNumber()).toEqual(expectedMoves)
 
       chess.header(...position.header)
 

--- a/__tests__/remove.test.ts
+++ b/__tests__/remove.test.ts
@@ -1,17 +1,48 @@
-import {
-  Chess,
-  Square,
-  QUEEN,
-  WHITE,
-  KNIGHT,
-  BISHOP,
-  BLACK,
-} from '../src/chess'
+import { Chess, Square, QUEEN, WHITE } from '../src/chess'
 
 test('remove - returns piece', () => {
   const chess = new Chess()
   expect(chess.remove('d1')).toEqual({ type: QUEEN, color: WHITE })
   expect(chess.get('d1')).toEqual(undefined)
+})
+
+test('remove - reaching initial position deletes setup headers', () => {
+  const chess = new Chess()
+  chess.loadPgn(`[SetUp "1"]
+    [FEN "rnbqkbnr/pppppppp/p7/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
+
+*`)
+
+  chess.remove('a6')
+
+  const headers = chess.getHeaders()
+  expect(headers['Setup']).toBeUndefined()
+  expect(headers['FEN']).toBeUndefined()
+})
+
+test('remove - if a move has been made, reaching initial position does not delete setup headers', () => {
+  const chess = new Chess()
+  chess.loadPgn(`[SetUp "1"]
+    [FEN "rnbqkbnr/pppppppp/p7/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
+
+*`)
+
+  // Shuffle the knights
+  chess.move('Nf3')
+  chess.move('Nf6')
+  chess.move('Ng1')
+  chess.move('Ng8')
+
+  // Reach the initial position.
+  chess.remove('a6')
+
+  /**
+   * The FEN header should not have been deleted despite reach
+   * initial position. However, Setup header may have been deleted
+   * unrelatedly.
+   */
+  const headers = chess.getHeaders()
+  expect(headers['FEN']).toBeDefined()
 })
 
 test('remove - returns undefined for empty square', () => {

--- a/__tests__/square-color.test.ts
+++ b/__tests__/square-color.test.ts
@@ -1,0 +1,20 @@
+import { Chess, type Square } from '../src/chess'
+
+test('squareColor should return light for light squares', () => {
+  const chess = new Chess()
+  expect(chess.squareColor('a8')).toBe('light')
+  expect(chess.squareColor('h1')).toBe('light')
+  expect(chess.squareColor('e4')).toBe('light')
+})
+
+test('squareColor should return dark for dark squares', () => {
+  const chess = new Chess()
+  expect(chess.squareColor('a1')).toBe('dark')
+  expect(chess.squareColor('h8')).toBe('dark')
+  expect(chess.squareColor('d4')).toBe('dark')
+})
+
+test('squareColor should return null for out of bounds squares', () => {
+  const chess = new Chess()
+  expect(chess.squareColor('h9' as Square)).toBeNull()
+})

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -11,9 +11,3 @@ test('undo - works', () => {
 
   chess.undo()
 })
-
-test('undo - works - nothing to undo', () => {
-  const chess = new Chess()
-
-  chess.undo()
-})

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -1,0 +1,19 @@
+import { Chess } from '../src/chess'
+
+test('undo - works', () => {
+  const chess = new Chess()
+
+  chess.move('e4')
+  chess.move('e5')
+  expect(chess.undo()?.san).toEqual('e5')
+  expect(chess.undo()?.san).toEqual('e4')
+  expect(chess.undo()).toBeNull()
+
+  chess.undo()
+})
+
+test('undo - works - nothing to undo', () => {
+  const chess = new Chess()
+
+  chess.undo()
+})

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint src/ --ext .ts",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
These two tests test the behavior regarding Setup/FEN tags and the remove function. 

I decided to squeeze more lines of coverage by testing  a couple untested but documented use cases.

I've been digging through the coverage reports and I think one remaining gap of note is  [998](file:///home/bestieboots/projects/community/chess.js/coverage/lcov-report/src/chess.ts.html#L998) to 1006 (note both the unreached code and the many untaken branches. 