### PR TITLE
Allow user to always include enpassant square in fen()

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,12 @@ chess.fen()
 // -> '8/8/8/8/8/8/8/8 w - - 0 1' <- empty board
 ```
 
-### .fen()
+### .fen({ forceEnpassantSquare = false) = {})
 
 Returns the FEN string for the current position. Note, the en passant square is
 only included if the side-to-move can legally capture en passant.
+
+The enpassant square will always be included if forceEnpassantSquare is true.
 
 ```ts
 const chess = new Chess()

--- a/__tests__/fen.test.ts
+++ b/__tests__/fen.test.ts
@@ -40,3 +40,14 @@ test('fen - ep square only if en passant is legal (illegal - pinned - #2)', () =
     'rnb1kbn1/p1p2p2/PpPp2qr/4pPp1/8/R1P4p/1PK1P1PP/1NBQ1BNR w - - 0 2',
   )
 })
+
+test('fen - allow EP square to be included by option', () => {
+  // black queen pins the ep pawn, making ep illegal (submitted by @ajax333221)
+  const chess = new Chess(
+    'rnb1kbn1/p1p1pp2/PpPp2qr/5Pp1/8/R1P4p/1PK1P1PP/1NBQ1BNR b - - 0 1',
+  )
+  chess.move('e5')
+  expect(chess.fen({ forceEnpassantSquare: true })).toEqual(
+    'rnb1kbn1/p1p2p2/PpPp2qr/4pPp1/8/R1P4p/1PK1P1PP/1NBQ1BNR w - e6 0 2',
+  )
+})

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -807,7 +807,9 @@ export class Chess {
     this._incPositionCount()
   }
 
-  fen() {
+  fen({
+    forceEnpassantSquare = false,
+  }: { forceEnpassantSquare?: boolean } = {}) {
     let empty = 0
     let fen = ''
 
@@ -861,38 +863,42 @@ export class Chess {
      * and ep capture is not pinned)
      */
     if (this._epSquare !== EMPTY) {
-      const bigPawnSquare = this._epSquare + (this._turn === WHITE ? 16 : -16)
-      const squares = [bigPawnSquare + 1, bigPawnSquare - 1]
+      if (forceEnpassantSquare) {
+        epSquare = algebraic(this._epSquare)
+      } else {
+        const bigPawnSquare = this._epSquare + (this._turn === WHITE ? 16 : -16)
+        const squares = [bigPawnSquare + 1, bigPawnSquare - 1]
 
-      for (const square of squares) {
-        // is the square off the board?
-        if (square & 0x88) {
-          continue
-        }
+        for (const square of squares) {
+          // is the square off the board?
+          if (square & 0x88) {
+            continue
+          }
 
-        const color = this._turn
+          const color = this._turn
 
-        // is there a pawn that can capture the epSquare?
-        if (
-          this._board[square]?.color === color &&
-          this._board[square]?.type === PAWN
-        ) {
-          // if the pawn makes an ep capture, does it leave its king in check?
-          this._makeMove({
-            color,
-            from: square,
-            to: this._epSquare,
-            piece: PAWN,
-            captured: PAWN,
-            flags: BITS.EP_CAPTURE,
-          })
-          const isLegal = !this._isKingAttacked(color)
-          this._undoMove()
+          // is there a pawn that can capture the epSquare?
+          if (
+            this._board[square]?.color === color &&
+            this._board[square]?.type === PAWN
+          ) {
+            // if the pawn makes an ep capture, does it leave its king in check?
+            this._makeMove({
+              color,
+              from: square,
+              to: this._epSquare,
+              piece: PAWN,
+              captured: PAWN,
+              flags: BITS.EP_CAPTURE,
+            })
+            const isLegal = !this._isKingAttacked(color)
+            this._undoMove()
 
-          // if ep is legal, break and set the ep square in the FEN output
-          if (isLegal) {
-            epSquare = algebraic(this._epSquare)
-            break
+            // if ep is legal, break and set the ep square in the FEN output
+            if (isLegal) {
+              epSquare = algebraic(this._epSquare)
+              break
+            }
           }
         }
       }


### PR DESCRIPTION
Adds an option to fen() which will include the enpassant square regardless of whether the option can actually be exercised or not on the next move.

My use case for this is compatibility with another library.