### PR TITLE
Zobrist hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,11 +340,11 @@ chess.getHeaders()
 
 ### .hash()
 
-Returns a unique 64-bit bigint hash for the current position.
+Returns a unique 64-bit hash as a hexidecimal string for the current position.
 
 ```ts
 chess.hash()
-// -> 3762458558257837166n
+// -> '3436f01fd716346e'
 ```
 
 ### .history([ options ])

--- a/README.md
+++ b/README.md
@@ -338,6 +338,15 @@ chess.getHeaders()
 // -> { White: 'Morphy', Black: 'Anderssen', Date: '1858-??-??' }
 ```
 
+### .hash()
+
+Returns a unique 64-bit bigint hash for the current position.
+
+```ts
+chess.hash()
+// -> 3762458558257837166n
+```
+
 ### .history([ options ])
 
 Returns a list containing the moves of the current game. Options is an optional

--- a/__tests__/clear.test.ts
+++ b/__tests__/clear.test.ts
@@ -8,6 +8,10 @@ test('clear', () => {
   chess.clear()
   expect(chess.fen()).toEqual('8/8/8/8/8/8/8/8 w - - 0 1')
   expect(chess.getHeaders()).toEqual({ ...SEVEN_TAG_ROSTER })
+
+  expect(chess.hash()).toEqual(
+    new Chess('8/8/8/8/8/8/8/8 w - - 0 1', { skipValidation: true }).hash(),
+  )
 })
 
 test('clear - preserveHeaders = true', () => {

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -28,6 +28,10 @@ test('loadPgn - works', () => {
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - no header', () => {
@@ -41,6 +45,10 @@ Qxh1 Bxb2 21. Qh4+ Kd7 22. Rb1 Bxa3 23. Qa4+`
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - no moves', () => {
@@ -50,6 +58,10 @@ test('loadPgn - works - no moves', () => {
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - no moves (header only)', () => {
@@ -62,6 +74,10 @@ test('loadPgn - works - no moves (header only)', () => {
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - empty game', () => {
@@ -71,6 +87,10 @@ test('loadPgn - works - empty game', () => {
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - comments', () => {
@@ -113,6 +133,10 @@ pawn, is hanging, the bishop is blocked because of the Queen.--Fischer} b5
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - comments (before first move)', () => {
@@ -160,6 +184,10 @@ Bogo-Indian. } 3...d5 4.Bg2 c6 5.Nf3 Be7 6.O-O Nbd7
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - regression test (pinned piece)', () => {
@@ -172,6 +200,10 @@ test('loadPgn - works - regression test (pinned piece)', () => {
   const pgn = '1. d4 Nf6 2. c4 e6 3. Nf3 c5 4. Nc3 cxd4 5. Nxd4 Bb4 6. Nb5'
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - move annotations', () => {
@@ -180,6 +212,10 @@ test('loadPgn - works - move annotations', () => {
   const pgn = '1. e4!! e5?! 2. d4?? d5!?'
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - move annotations (including check symbols)', () => {
@@ -189,6 +225,10 @@ test('loadPgn - works - move annotations (including check symbols)', () => {
     '1.e4 e6 2.d4 d5 3.exd5 c6?? 4.dxe6 Nf6?! 5.exf7+!! Kd7!? 6.Nf3 Bd6 7.f8=N+!! Qxf8'
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - prunes recursive annotation variations (RAV)', () => {
@@ -199,6 +239,10 @@ test('loadPgn - works - prunes recursive annotation variations (RAV)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual([])
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - preserves RAV inside comments', () => {
@@ -227,6 +271,10 @@ Nf6 21. Qh3 Bc6 22. Kg1 Qb8 23. Qg3 Nh5 24. Qf2 Bf6 25. Be2 Bxd4
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - mixed RAV and comments', () => {
@@ -246,6 +294,10 @@ test('loadPgn - works - mixed RAV and comments', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - FEN and SetUp tag', () => {
@@ -260,6 +312,10 @@ test('loadPgn - works - FEN and SetUp tag', () => {
 17.Rd8# 1-0`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - strict - SetUp tag requires FEN tag', () => {
@@ -288,6 +344,10 @@ test('loadPgn - strict - FEN and SetUp tag', () => {
 17.Rd8# 1-0`
   chess.loadPgn(pgn, { strict: true })
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test("loadPgn - works - prunes numeric annotation glyphs (NAG's)", () => {
@@ -302,6 +362,10 @@ test("loadPgn - works - prunes numeric annotation glyphs (NAG's)", () => {
 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - messy whitespace (tabs, whitespace, and mixed newlines)', () => {
@@ -335,6 +399,10 @@ test('loadPgn - works - messy whitespace (tabs, whitespace, and mixed newlines)'
   // spot check a few of the header values
   expect(chess.header()['Event']).toEqual('Reykjavik WCh')
   expect(chess.header()['Round']).toEqual('6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - parses different newline characters', () => {
@@ -382,6 +450,10 @@ test('loadPgn - works - parses different newline characters', () => {
     expect(chess.fen()).toEqual(fen)
     expect(chess.getComments()).toEqual(comments)
   })
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (unnecessary disambiguation - #1)', () => {
@@ -400,6 +472,10 @@ Ng4 23.Rxd7+ Kc6 24.Rxf7 Bxb2 25.Rxg7 Ne3 26.Rg3 Bd4 27.Kh1 Rxa2 28.Rc1+ Kb6
   // but the sloppy parse will handle it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (unnecessary disambiguation - #2)', () => {
@@ -418,6 +494,10 @@ Rc4-d4 Rb7 29. Qf7 Rc7 30. Qe8# 1-0`
   // the sloppy parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (correctly disambiguated move - #1)', () => {
@@ -437,6 +517,10 @@ Ng4 23.Rxd7+ Kc6 24.Rxf7 Bxb2 25.Rxg7 Ne3 26.Rg3 Bd4 27.Kh1 Rxa2 28.Rc1+ Kb6
   expect(chess.fen()).toEqual(fen)
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (correctly disambiguated move - #2)', () => {
@@ -450,6 +534,10 @@ test('loadPgn - works - permissive parser (correctly disambiguated move - #2)', 
   expect(chess.fen()).toEqual(fen)
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (alebraic notation)', () => {
@@ -467,6 +555,10 @@ d3h7`
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (alebraic notation with symbols and en passant)', () => {
@@ -487,6 +579,10 @@ e6d5 30. f3d1 f7h5 31. c2h2 g4g3+ 32. f4g3 g8g3+ 33. g1f2 h5h2+ 34. f2e1 g3g2
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (alebraic notation with underpromotion)', () => {
@@ -513,6 +609,10 @@ h5h4 67. f7f8Q h4h5 68. f8h8# 1-0`
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (extended long alebraic notation)', () => {
@@ -539,6 +639,10 @@ Rb7b6 Kc5b6 58. d6d7 Kb6c7 59. Ke5e6 1-0
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (extended long alebraic notation with hyphens)', () => {
@@ -568,6 +672,10 @@ Kh4-h5 68. Qf8-h8# 1-0`
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (FEN without SetUp tag)', () => {
@@ -586,6 +694,10 @@ test('loadPgn - works - permissive parser (FEN without SetUp tag)', () => {
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - works - permissive parser (FEN tag case insensitive)', () => {
@@ -604,6 +716,10 @@ test('loadPgn - works - permissive parser (FEN tag case insensitive)', () => {
   // the permissive parser should accept it
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('loadPgn - throws Error (illegal move)', () => {

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -29,9 +29,7 @@ test('loadPgn - works', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - no header', () => {
@@ -46,9 +44,7 @@ Qxh1 Bxb2 21. Qh4+ Kd7 22. Rb1 Bxa3 23. Qa4+`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - no moves', () => {
@@ -59,9 +55,7 @@ test('loadPgn - works - no moves', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - no moves (header only)', () => {
@@ -75,9 +69,7 @@ test('loadPgn - works - no moves (header only)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - empty game', () => {
@@ -88,9 +80,7 @@ test('loadPgn - works - empty game', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(DEFAULT_POSITION)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - comments', () => {
@@ -134,9 +124,7 @@ pawn, is hanging, the bishop is blocked because of the Queen.--Fischer} b5
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - comments (before first move)', () => {
@@ -185,9 +173,7 @@ Bogo-Indian. } 3...d5 4.Bg2 c6 5.Nf3 Be7 6.O-O Nbd7
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - regression test (pinned piece)', () => {
@@ -201,9 +187,7 @@ test('loadPgn - works - regression test (pinned piece)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - move annotations', () => {
@@ -213,9 +197,7 @@ test('loadPgn - works - move annotations', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - move annotations (including check symbols)', () => {
@@ -226,9 +208,7 @@ test('loadPgn - works - move annotations (including check symbols)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - prunes recursive annotation variations (RAV)', () => {
@@ -240,9 +220,7 @@ test('loadPgn - works - prunes recursive annotation variations (RAV)', () => {
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual([])
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - preserves RAV inside comments', () => {
@@ -272,9 +250,7 @@ Nf6 21. Qh3 Bc6 22. Kg1 Qb8 23. Qg3 Nh5 24. Qf2 Bf6 25. Be2 Bxd4
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - mixed RAV and comments', () => {
@@ -295,9 +271,7 @@ test('loadPgn - works - mixed RAV and comments', () => {
   expect(chess.fen()).toEqual(fen)
   expect(chess.getComments()).toEqual(comments)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - FEN and SetUp tag', () => {
@@ -313,9 +287,7 @@ test('loadPgn - works - FEN and SetUp tag', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - strict - SetUp tag requires FEN tag', () => {
@@ -345,9 +317,7 @@ test('loadPgn - strict - FEN and SetUp tag', () => {
   chess.loadPgn(pgn, { strict: true })
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test("loadPgn - works - prunes numeric annotation glyphs (NAG's)", () => {
@@ -363,9 +333,7 @@ test("loadPgn - works - prunes numeric annotation glyphs (NAG's)", () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - messy whitespace (tabs, whitespace, and mixed newlines)', () => {
@@ -400,9 +368,7 @@ test('loadPgn - works - messy whitespace (tabs, whitespace, and mixed newlines)'
   expect(chess.header()['Event']).toEqual('Reykjavik WCh')
   expect(chess.header()['Round']).toEqual('6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - parses different newline characters', () => {
@@ -451,9 +417,7 @@ test('loadPgn - works - parses different newline characters', () => {
     expect(chess.getComments()).toEqual(comments)
   })
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (unnecessary disambiguation - #1)', () => {
@@ -473,9 +437,7 @@ Ng4 23.Rxd7+ Kc6 24.Rxf7 Bxb2 25.Rxg7 Ne3 26.Rg3 Bd4 27.Kh1 Rxa2 28.Rc1+ Kb6
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (unnecessary disambiguation - #2)', () => {
@@ -495,9 +457,7 @@ Rc4-d4 Rb7 29. Qf7 Rc7 30. Qe8# 1-0`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (correctly disambiguated move - #1)', () => {
@@ -518,9 +478,7 @@ Ng4 23.Rxd7+ Kc6 24.Rxf7 Bxb2 25.Rxg7 Ne3 26.Rg3 Bd4 27.Kh1 Rxa2 28.Rc1+ Kb6
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (correctly disambiguated move - #2)', () => {
@@ -535,9 +493,7 @@ test('loadPgn - works - permissive parser (correctly disambiguated move - #2)', 
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (alebraic notation)', () => {
@@ -556,9 +512,7 @@ d3h7`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (alebraic notation with symbols and en passant)', () => {
@@ -580,9 +534,7 @@ e6d5 30. f3d1 f7h5 31. c2h2 g4g3+ 32. f4g3 g8g3+ 33. g1f2 h5h2+ 34. f2e1 g3g2
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (alebraic notation with underpromotion)', () => {
@@ -610,9 +562,7 @@ h5h4 67. f7f8Q h4h5 68. f8h8# 1-0`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (extended long alebraic notation)', () => {
@@ -640,9 +590,7 @@ Rb7b6 Kc5b6 58. d6d7 Kb6c7 59. Ke5e6 1-0
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (extended long alebraic notation with hyphens)', () => {
@@ -673,9 +621,7 @@ Kh4-h5 68. Qf8-h8# 1-0`
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (FEN without SetUp tag)', () => {
@@ -695,9 +641,7 @@ test('loadPgn - works - permissive parser (FEN without SetUp tag)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - works - permissive parser (FEN tag case insensitive)', () => {
@@ -717,9 +661,7 @@ test('loadPgn - works - permissive parser (FEN tag case insensitive)', () => {
   chess.loadPgn(pgn)
   expect(chess.fen()).toEqual(fen)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('loadPgn - throws Error (illegal move)', () => {

--- a/__tests__/move.test.ts
+++ b/__tests__/move.test.ts
@@ -14,9 +14,9 @@ test('move - works - standard algebraic notation', () => {
   expect(move.after).toEqual(chess.fen())
   expect(chess.fen()).toEqual(next)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - standard algebraic notation (mates)', () => {
@@ -33,9 +33,9 @@ test('move - works - standard algebraic notation (mates)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - standard algebraic notation (white en passant)', () => {
@@ -59,9 +59,9 @@ test('move - works - standard algebraic notation (white en passant)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - standard algebraic notation (black en passant)', () => {
@@ -84,9 +84,9 @@ test('move - works - standard algebraic notation (black en passant)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - standard algebraic notation (pin disambiguates piece)', () => {
@@ -109,9 +109,9 @@ test('move - works - standard algebraic notation (pin disambiguates piece)', () 
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - permissive parser (accepts overly disambiguated piece)', () => {
@@ -132,9 +132,9 @@ test('move - works - permissive parser (accepts overly disambiguated piece)', ()
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - permissive parser (accepts correctly disambiguated piece)', () => {
@@ -155,9 +155,9 @@ test('move - works - permissive parser (accepts correctly disambiguated piece)',
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - strict - throws Error - overly disambiguated piece', () => {
@@ -186,9 +186,9 @@ test('move - works - verbose', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(true)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - verbose - promotion field ignored if not promoting', () => {
@@ -204,9 +204,9 @@ test('move - works - verbose - promotion field ignored if not promoting', () => 
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(true)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - verbose - under promotion', () => {
@@ -223,9 +223,9 @@ test('move - works - verbose - under promotion', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - throws Error - verbose (illegal move)', () => {
@@ -255,9 +255,9 @@ test('move - works - permissive parser (piece capture without x)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - permissive parser (pawn capture without x)', () => {
@@ -279,9 +279,9 @@ test('move - works - permissive parser (pawn capture without x)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - permissive parser (en passant capture without x)', () => {
@@ -303,9 +303,9 @@ test('move - works - permissive parser (en passant capture without x)', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
 
-  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(next).hash())
   chess.undo()
-  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
+  expect(chess.hash()).toEqual(new Chess(fen).hash())
 })
 
 test('move - works - kingside castling', () => {
@@ -326,13 +326,9 @@ test('move - works - kingside castling', () => {
     expect(move.after).toEqual(chess.fen())
     expect(chess.fen()).toEqual(next)
 
-    expect(chess.hash().toString(16)).toEqual(
-      new Chess(next).hash().toString(16),
-    )
+    expect(chess.hash()).toEqual(new Chess(next).hash())
     chess.undo()
-    expect(chess.hash().toString(16)).toEqual(
-      new Chess(fen).hash().toString(16),
-    )
+    expect(chess.hash()).toEqual(new Chess(fen).hash())
   }
 })
 
@@ -354,13 +350,9 @@ test('move - works - queenside castling', () => {
     expect(move.after).toEqual(chess.fen())
     expect(chess.fen()).toEqual(next)
 
-    expect(chess.hash().toString(16)).toEqual(
-      new Chess(next).hash().toString(16),
-    )
+    expect(chess.hash()).toEqual(new Chess(next).hash())
     chess.undo()
-    expect(chess.hash().toString(16)).toEqual(
-      new Chess(fen).hash().toString(16),
-    )
+    expect(chess.hash()).toEqual(new Chess(fen).hash())
   }
 })
 

--- a/__tests__/move.test.ts
+++ b/__tests__/move.test.ts
@@ -13,6 +13,10 @@ test('move - works - standard algebraic notation', () => {
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.after).toEqual(chess.fen())
   expect(chess.fen()).toEqual(next)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - standard algebraic notation (mates)', () => {
@@ -28,6 +32,10 @@ test('move - works - standard algebraic notation (mates)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - standard algebraic notation (white en passant)', () => {
@@ -50,6 +58,10 @@ test('move - works - standard algebraic notation (white en passant)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - standard algebraic notation (black en passant)', () => {
@@ -71,6 +83,10 @@ test('move - works - standard algebraic notation (black en passant)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - standard algebraic notation (pin disambiguates piece)', () => {
@@ -92,6 +108,10 @@ test('move - works - standard algebraic notation (pin disambiguates piece)', () 
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - permissive parser (accepts overly disambiguated piece)', () => {
@@ -111,6 +131,10 @@ test('move - works - permissive parser (accepts overly disambiguated piece)', ()
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - permissive parser (accepts correctly disambiguated piece)', () => {
@@ -130,6 +154,10 @@ test('move - works - permissive parser (accepts correctly disambiguated piece)',
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - strict - throws Error - overly disambiguated piece', () => {
@@ -157,6 +185,10 @@ test('move - works - verbose', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(true)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - verbose - promotion field ignored if not promoting', () => {
@@ -171,6 +203,10 @@ test('move - works - verbose - promotion field ignored if not promoting', () => 
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(true)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - verbose - under promotion', () => {
@@ -186,6 +222,10 @@ test('move - works - verbose - under promotion', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - throws Error - verbose (illegal move)', () => {
@@ -214,6 +254,10 @@ test('move - works - permissive parser (piece capture without x)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - permissive parser (pawn capture without x)', () => {
@@ -234,6 +278,10 @@ test('move - works - permissive parser (pawn capture without x)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - permissive parser (en passant capture without x)', () => {
@@ -254,6 +302,10 @@ test('move - works - permissive parser (en passant capture without x)', () => {
   expect(move.isKingsideCastle()).toEqual(false)
   expect(move.isQueensideCastle()).toEqual(false)
   expect(move.isBigPawn()).toEqual(false)
+
+  expect(chess.hash().toString(16)).toEqual(new Chess(next).hash().toString(16))
+  chess.undo()
+  expect(chess.hash().toString(16)).toEqual(new Chess(fen).hash().toString(16))
 })
 
 test('move - works - kingside castling', () => {
@@ -273,6 +325,14 @@ test('move - works - kingside castling', () => {
     expect(move.isQueensideCastle()).toEqual(false)
     expect(move.after).toEqual(chess.fen())
     expect(chess.fen()).toEqual(next)
+
+    expect(chess.hash().toString(16)).toEqual(
+      new Chess(next).hash().toString(16),
+    )
+    chess.undo()
+    expect(chess.hash().toString(16)).toEqual(
+      new Chess(fen).hash().toString(16),
+    )
   }
 })
 
@@ -293,6 +353,14 @@ test('move - works - queenside castling', () => {
     expect(move.isQueensideCastle()).toEqual(true)
     expect(move.after).toEqual(chess.fen())
     expect(chess.fen()).toEqual(next)
+
+    expect(chess.hash().toString(16)).toEqual(
+      new Chess(next).hash().toString(16),
+    )
+    chess.undo()
+    expect(chess.hash().toString(16)).toEqual(
+      new Chess(fen).hash().toString(16),
+    )
   }
 })
 

--- a/__tests__/position-counts.test.ts
+++ b/__tests__/position-counts.test.ts
@@ -3,22 +3,22 @@ import { Chess as ChessClass, DEFAULT_POSITION } from '../src/chess'
 // We need to use `Chess as any` to access private property
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
 const Chess = ChessClass as any
-const defaultHash = new Chess(DEFAULT_POSITION).hash()
+const defaultHash = BigInt('0x' + new Chess(DEFAULT_POSITION).hash())
 const e4Fen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
-const e4Hash = new Chess(e4Fen).hash()
+const e4Hash = BigInt('0x' + new Chess(e4Fen).hash())
 
 test('positionCount - counts repeated positions', () => {
   const chess = new Chess()
   expect(chess._getPositionCount(defaultHash)).toBe(1)
 
-  const hashes: string[] = [defaultHash]
+  const hashes: bigint[] = [defaultHash]
   const moves: string[] = ['Nf3', 'Nf6', 'Ng1', 'Ng8']
   for (const move of moves) {
     for (const hash of hashes) {
       expect(chess._getPositionCount(hash)).toBe(1)
     }
     chess.move(move)
-    hashes.push(chess.hash())
+    hashes.push(BigInt('0x' + chess.hash()))
   }
   expect(chess._getPositionCount(defaultHash)).toBe(2)
   expect(chess._positionCount.size).toBe(4)
@@ -58,7 +58,7 @@ test('positionCount - resets when loading FEN', () => {
   const newFen =
     'rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
   chess.load(newFen)
-  const newHash = chess.hash()
+  const newHash = BigInt('0x' + chess.hash())
 
   expect(chess._getPositionCount(defaultHash)).toBe(0)
   expect(chess._getPositionCount(e4Hash)).toBe(0)
@@ -75,16 +75,22 @@ test('positionCount - resets when loading PGN', () => {
   expect(chess._getPositionCount(e4Hash)).toBe(0)
   expect(
     chess._getPositionCount(
-      new Chess(
-        'rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1',
-      ).hash(),
+      BigInt(
+        '0x' +
+          new Chess(
+            'rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1',
+          ).hash(),
+      ),
     ),
   ).toBe(1)
   expect(
     chess._getPositionCount(
-      new Chess(
-        'rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2',
-      ).hash(),
+      BigInt(
+        '0x' +
+          new Chess(
+            'rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2',
+          ).hash(),
+      ),
     ),
   ).toBe(1)
   expect(chess._positionCount.size).toBe(3)

--- a/__tests__/position-counts.test.ts
+++ b/__tests__/position-counts.test.ts
@@ -3,38 +3,40 @@ import { Chess as ChessClass, DEFAULT_POSITION } from '../src/chess'
 // We need to use `Chess as any` to access private property
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
 const Chess = ChessClass as any
+const defaultHash = new Chess(DEFAULT_POSITION).hash()
 const e4Fen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+const e4Hash = new Chess(e4Fen).hash()
 
 test('positionCount - counts repeated positions', () => {
   const chess = new Chess()
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
 
-  const fens: string[] = [DEFAULT_POSITION]
+  const hashes: string[] = [defaultHash]
   const moves: string[] = ['Nf3', 'Nf6', 'Ng1', 'Ng8']
   for (const move of moves) {
-    for (const fen of fens) {
-      expect(chess._getPositionCount(fen)).toBe(1)
+    for (const hash of hashes) {
+      expect(chess._getPositionCount(hash)).toBe(1)
     }
     chess.move(move)
-    fens.push(chess.fen())
+    hashes.push(chess.hash())
   }
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(2)
-  expect(Object.keys(chess._positionCount).length).toBe(4)
+  expect(chess._getPositionCount(defaultHash)).toBe(2)
+  expect(chess._positionCount.size).toBe(4)
 })
 
 test('positionCount - removes when undo', () => {
   const chess = new Chess()
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
-  expect(chess._getPositionCount(e4Fen)).toBe(0)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
+  expect(chess._getPositionCount(e4Hash)).toBe(0)
   chess.move('e4')
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
   expect(chess.fen()).toBe(e4Fen)
-  expect(chess._getPositionCount(e4Fen)).toBe(1)
+  expect(chess._getPositionCount(e4Hash)).toBe(1)
 
   chess.undo()
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
-  expect(chess._getPositionCount(e4Fen)).toBe(0)
-  expect(Object.keys(chess._positionCount).length).toBe(1)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
+  expect(chess._getPositionCount(e4Hash)).toBe(0)
+  expect(chess._positionCount.size).toBe(1)
 })
 
 test('positionCount - resets when cleared', () => {
@@ -42,24 +44,26 @@ test('positionCount - resets when cleared', () => {
 
   chess.move('e4')
   chess.clear()
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(0)
-  expect(Object.keys(chess._positionCount).length).toBe(0)
+  expect(chess._getPositionCount(defaultHash)).toBe(0)
+  expect(chess._positionCount.size).toBe(0)
 })
 
 test('positionCount - resets when loading FEN', () => {
   const chess = new Chess()
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
   chess.move('e4')
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
-  expect(chess._getPositionCount(e4Fen)).toBe(1)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
+  expect(chess._getPositionCount(e4Hash)).toBe(1)
 
   const newFen =
     'rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
   chess.load(newFen)
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(0)
-  expect(chess._getPositionCount(e4Fen)).toBe(0)
-  expect(chess._getPositionCount(newFen)).toBe(1)
-  expect(Object.keys(chess._positionCount).length).toBe(1)
+  const newHash = chess.hash()
+
+  expect(chess._getPositionCount(defaultHash)).toBe(0)
+  expect(chess._getPositionCount(e4Hash)).toBe(0)
+  expect(chess._getPositionCount(newHash)).toBe(1)
+  expect(chess._positionCount.size).toBe(1)
 })
 
 test('positionCount - resets when loading PGN', () => {
@@ -67,17 +71,21 @@ test('positionCount - resets when loading PGN', () => {
   chess.move('e4')
 
   chess.loadPgn('1. d4 d5')
-  expect(chess._getPositionCount(DEFAULT_POSITION)).toBe(1)
-  expect(chess._getPositionCount(e4Fen)).toBe(0)
+  expect(chess._getPositionCount(defaultHash)).toBe(1)
+  expect(chess._getPositionCount(e4Hash)).toBe(0)
   expect(
     chess._getPositionCount(
-      'rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1',
+      new Chess(
+        'rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1',
+      ).hash(),
     ),
   ).toBe(1)
   expect(
     chess._getPositionCount(
-      'rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2',
+      new Chess(
+        'rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 2',
+      ).hash(),
     ),
   ).toBe(1)
-  expect(Object.keys(chess._positionCount).length).toBe(3)
+  expect(chess._positionCount.size).toBe(3)
 })

--- a/__tests__/put.test.ts
+++ b/__tests__/put.test.ts
@@ -22,6 +22,10 @@ test('put', () => {
   }
   expect(chess.put(piece, 'a1')).toEqual(true)
   expect(chess.get('a1')).toEqual(piece)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 //test('put - capitalized square', () => {
@@ -67,6 +71,10 @@ test('put - allow two kings if overwriting the same square', () => {
   const piece: Piece = { type: KING, color: WHITE }
   expect(chess.put(piece, 'a2')).toEqual(true)
   expect(chess.put(piece, 'a2')).toEqual(true)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 test('put - replacing white kingside rook loses castling right', () => {
@@ -74,6 +82,10 @@ test('put - replacing white kingside rook loses castling right', () => {
 
   chess.put({ type: KNIGHT, color: WHITE }, 'h1')
   expect(chess.moves()).not.toContain('O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing white queenside rook loses castling right', () => {
@@ -81,6 +93,10 @@ test('put - replacing white queenside rook loses castling right', () => {
 
   chess.put({ type: KNIGHT, color: WHITE }, 'a1')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing white king loses castling rights', () => {
@@ -89,6 +105,10 @@ test('put - replacing white king loses castling rights', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'e1')
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 test('put - replacing black kingside rook loses castling right', () => {
@@ -96,6 +116,10 @@ test('put - replacing black kingside rook loses castling right', () => {
 
   chess.put({ type: KNIGHT, color: BLACK }, 'h8')
   expect(chess.moves()).not.toContain('O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing black queenside rook loses castling right', () => {
@@ -103,6 +127,10 @@ test('put - replacing black queenside rook loses castling right', () => {
 
   chess.put({ type: KNIGHT, color: BLACK }, 'a8')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing black king loses castling rights', () => {
@@ -111,6 +139,10 @@ test('put - replacing black king loses castling rights', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'e8')
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 test('put - replacing white pawn clears en passant square', () => {
@@ -120,6 +152,10 @@ test('put - replacing white pawn clears en passant square', () => {
 
   chess.put({ type: KNIGHT, color: WHITE }, 'f4')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - occupying white en passant square clears it', () => {
@@ -129,6 +165,10 @@ test('put - occupying white en passant square clears it', () => {
 
   chess.put({ type: KNIGHT, color: BLACK }, 'f3')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - occupying white starting square clears en passant square', () => {
@@ -138,6 +178,10 @@ test('put - occupying white starting square clears en passant square', () => {
 
   chess.put({ type: KNIGHT, color: WHITE }, 'f2')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing black pawn clears white en passant square 1', () => {
@@ -147,6 +191,10 @@ test('put - replacing black pawn clears white en passant square 1', () => {
 
   chess.put({ type: BISHOP, color: BLACK }, 'g4')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing black pawn clears white en passant square 2', () => {
@@ -156,6 +204,10 @@ test('put - replacing black pawn clears white en passant square 2', () => {
 
   chess.put({ type: BISHOP, color: BLACK }, 'b4')
   expect(chess.moves()).not.toContain('bxc3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing black pawn clears en passant square', () => {
@@ -165,6 +217,10 @@ test('put - replacing black pawn clears en passant square', () => {
 
   chess.put({ type: KNIGHT, color: BLACK }, 'f5')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - occupying black en passant square clears it', () => {
@@ -174,6 +230,10 @@ test('put - occupying black en passant square clears it', () => {
 
   chess.put({ type: KNIGHT, color: WHITE }, 'f6')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - occupying black starting square clears en passant square', () => {
@@ -183,6 +243,10 @@ test('put - occupying black starting square clears en passant square', () => {
 
   chess.put({ type: KNIGHT, color: BLACK }, 'f7')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing white pawn clears black en passant square 1', () => {
@@ -192,6 +256,10 @@ test('put - replacing white pawn clears black en passant square 1', () => {
 
   chess.put({ type: BISHOP, color: WHITE }, 'g5')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('put - replacing white pawn clears black en passant square 2', () => {
@@ -201,4 +269,8 @@ test('put - replacing white pawn clears black en passant square 2', () => {
 
   chess.put({ type: BISHOP, color: WHITE }, 'b5')
   expect(chess.moves()).not.toContain('bxc6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })

--- a/__tests__/put.test.ts
+++ b/__tests__/put.test.ts
@@ -23,8 +23,8 @@ test('put', () => {
   expect(chess.put(piece, 'a1')).toEqual(true)
   expect(chess.get('a1')).toEqual(piece)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -72,8 +72,8 @@ test('put - allow two kings if overwriting the same square', () => {
   expect(chess.put(piece, 'a2')).toEqual(true)
   expect(chess.put(piece, 'a2')).toEqual(true)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -83,8 +83,8 @@ test('put - replacing white kingside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'h1')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -94,8 +94,8 @@ test('put - replacing white queenside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'a1')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -106,8 +106,8 @@ test('put - replacing white king loses castling rights', () => {
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -117,8 +117,8 @@ test('put - replacing black kingside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'h8')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -128,8 +128,8 @@ test('put - replacing black queenside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'a8')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -140,8 +140,8 @@ test('put - replacing black king loses castling rights', () => {
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -153,8 +153,8 @@ test('put - replacing white pawn clears en passant square', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -166,8 +166,8 @@ test('put - occupying white en passant square clears it', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f3')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -179,8 +179,8 @@ test('put - occupying white starting square clears en passant square', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f2')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -192,8 +192,8 @@ test('put - replacing black pawn clears white en passant square 1', () => {
   chess.put({ type: BISHOP, color: BLACK }, 'g4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -205,8 +205,8 @@ test('put - replacing black pawn clears white en passant square 2', () => {
   chess.put({ type: BISHOP, color: BLACK }, 'b4')
   expect(chess.moves()).not.toContain('bxc3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -218,8 +218,8 @@ test('put - replacing black pawn clears en passant square', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -231,8 +231,8 @@ test('put - occupying black en passant square clears it', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f6')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -244,8 +244,8 @@ test('put - occupying black starting square clears en passant square', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f7')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -257,8 +257,8 @@ test('put - replacing white pawn clears black en passant square 1', () => {
   chess.put({ type: BISHOP, color: WHITE }, 'g5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -270,7 +270,7 @@ test('put - replacing white pawn clears black en passant square 2', () => {
   chess.put({ type: BISHOP, color: WHITE }, 'b5')
   expect(chess.moves()).not.toContain('bxc6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })

--- a/__tests__/put.test.ts
+++ b/__tests__/put.test.ts
@@ -83,9 +83,7 @@ test('put - replacing white kingside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'h1')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing white queenside rook loses castling right', () => {
@@ -94,9 +92,7 @@ test('put - replacing white queenside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'a1')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing white king loses castling rights', () => {
@@ -117,9 +113,7 @@ test('put - replacing black kingside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'h8')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing black queenside rook loses castling right', () => {
@@ -128,9 +122,7 @@ test('put - replacing black queenside rook loses castling right', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'a8')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing black king loses castling rights', () => {
@@ -153,9 +145,7 @@ test('put - replacing white pawn clears en passant square', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - occupying white en passant square clears it', () => {
@@ -166,9 +156,7 @@ test('put - occupying white en passant square clears it', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f3')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - occupying white starting square clears en passant square', () => {
@@ -179,9 +167,7 @@ test('put - occupying white starting square clears en passant square', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f2')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing black pawn clears white en passant square 1', () => {
@@ -192,9 +178,7 @@ test('put - replacing black pawn clears white en passant square 1', () => {
   chess.put({ type: BISHOP, color: BLACK }, 'g4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing black pawn clears white en passant square 2', () => {
@@ -205,9 +189,7 @@ test('put - replacing black pawn clears white en passant square 2', () => {
   chess.put({ type: BISHOP, color: BLACK }, 'b4')
   expect(chess.moves()).not.toContain('bxc3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing black pawn clears en passant square', () => {
@@ -218,9 +200,7 @@ test('put - replacing black pawn clears en passant square', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - occupying black en passant square clears it', () => {
@@ -231,9 +211,7 @@ test('put - occupying black en passant square clears it', () => {
   chess.put({ type: KNIGHT, color: WHITE }, 'f6')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - occupying black starting square clears en passant square', () => {
@@ -244,9 +222,7 @@ test('put - occupying black starting square clears en passant square', () => {
   chess.put({ type: KNIGHT, color: BLACK }, 'f7')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing white pawn clears black en passant square 1', () => {
@@ -257,9 +233,7 @@ test('put - replacing white pawn clears black en passant square 1', () => {
   chess.put({ type: BISHOP, color: WHITE }, 'g5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('put - replacing white pawn clears black en passant square 2', () => {
@@ -270,7 +244,5 @@ test('put - replacing white pawn clears black en passant square 2', () => {
   chess.put({ type: BISHOP, color: WHITE }, 'b5')
   expect(chess.moves()).not.toContain('bxc6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })

--- a/__tests__/remove.test.ts
+++ b/__tests__/remove.test.ts
@@ -13,8 +13,8 @@ test('remove - returns piece', () => {
   expect(chess.remove('d1')).toEqual({ type: QUEEN, color: WHITE })
   expect(chess.get('d1')).toEqual(undefined)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -22,8 +22,8 @@ test('remove - returns undefined for empty square', () => {
   const chess = new Chess()
   expect(chess.remove('e4')).toEqual(undefined)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -31,8 +31,8 @@ test('remove - returns undefined for invalid square', () => {
   const chess = new Chess()
   expect(chess.remove('bad_square' as Square)).toEqual(undefined)
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -42,8 +42,8 @@ test('remove - removing white kingside rook loses castling right', () => {
   chess.remove('h1')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -53,8 +53,8 @@ test('remove - removing white queenside rook loses castling right', () => {
   chess.remove('a1')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -65,8 +65,8 @@ test('remove - removing white king loses castling rights', () => {
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -76,8 +76,8 @@ test('remove - removing black kingside rook loses castling right', () => {
   chess.remove('h8')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -87,8 +87,8 @@ test('remove - removing black queenside rook loses castling right', () => {
   chess.remove('a8')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -99,8 +99,8 @@ test('remove - removing black king loses castling rights', () => {
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash(),
   )
 })
 
@@ -112,8 +112,8 @@ test('remove - removing white pawn clears en passant square', () => {
   chess.remove('f4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -125,8 +125,8 @@ test('remove - removing black pawn clears white en passant square 1', () => {
   chess.remove('g4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -138,8 +138,8 @@ test('remove - removing black pawn clears white en passant square 2', () => {
   chess.remove('b4')
   expect(chess.moves()).not.toContain('bxc3')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -151,8 +151,8 @@ test('remove - removing black pawn clears en passant square', () => {
   chess.remove('f5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -164,8 +164,8 @@ test('remove - removing white pawn clears black en passant square 1', () => {
   chess.remove('g5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -177,8 +177,8 @@ test('remove - removing white pawn clears black en passant square 2', () => {
   chess.remove('b5')
   expect(chess.moves()).not.toContain('bxc6')
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -195,8 +195,8 @@ test('remove - reaching initial position deletes setup headers', () => {
   expect(headers['Setup']).toBeUndefined()
   expect(headers['FEN']).toBeUndefined()
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })
 
@@ -224,7 +224,7 @@ test('remove - if a move has been made, reaching initial position does not delet
   const headers = chess.getHeaders()
   expect(headers['FEN']).toBeDefined()
 
-  expect(chess.hash().toString(16)).toEqual(
-    new Chess(chess.fen()).hash().toString(16),
+  expect(chess.hash()).toEqual(
+    new Chess(chess.fen()).hash(),
   )
 })

--- a/__tests__/remove.test.ts
+++ b/__tests__/remove.test.ts
@@ -12,16 +12,28 @@ test('remove - returns piece', () => {
   const chess = new Chess()
   expect(chess.remove('d1')).toEqual({ type: QUEEN, color: WHITE })
   expect(chess.get('d1')).toEqual(undefined)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - returns undefined for empty square', () => {
   const chess = new Chess()
   expect(chess.remove('e4')).toEqual(undefined)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - returns undefined for invalid square', () => {
   const chess = new Chess()
   expect(chess.remove('bad_square' as Square)).toEqual(undefined)
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing white kingside rook loses castling right', () => {
@@ -29,6 +41,10 @@ test('remove - removing white kingside rook loses castling right', () => {
 
   chess.remove('h1')
   expect(chess.moves()).not.toContain('O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing white queenside rook loses castling right', () => {
@@ -36,6 +52,10 @@ test('remove - removing white queenside rook loses castling right', () => {
 
   chess.remove('a1')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing white king loses castling rights', () => {
@@ -44,6 +64,10 @@ test('remove - removing white king loses castling rights', () => {
   chess.remove('e1')
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 test('remove - removing black kingside rook loses castling right', () => {
@@ -51,6 +75,10 @@ test('remove - removing black kingside rook loses castling right', () => {
 
   chess.remove('h8')
   expect(chess.moves()).not.toContain('O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing black queenside rook loses castling right', () => {
@@ -58,6 +86,10 @@ test('remove - removing black queenside rook loses castling right', () => {
 
   chess.remove('a8')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing black king loses castling rights', () => {
@@ -66,6 +98,10 @@ test('remove - removing black king loses castling rights', () => {
   chess.remove('e8')
   expect(chess.moves()).not.toContain('O-O')
   expect(chess.moves()).not.toContain('O-O-O')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen(), { skipValidation: true }).hash().toString(16),
+  )
 })
 
 test('remove - removing white pawn clears en passant square', () => {
@@ -75,6 +111,10 @@ test('remove - removing white pawn clears en passant square', () => {
 
   chess.remove('f4')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing black pawn clears white en passant square 1', () => {
@@ -84,6 +124,10 @@ test('remove - removing black pawn clears white en passant square 1', () => {
 
   chess.remove('g4')
   expect(chess.moves()).not.toContain('gxf3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing black pawn clears white en passant square 2', () => {
@@ -93,6 +137,10 @@ test('remove - removing black pawn clears white en passant square 2', () => {
 
   chess.remove('b4')
   expect(chess.moves()).not.toContain('bxc3')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing black pawn clears en passant square', () => {
@@ -102,6 +150,10 @@ test('remove - removing black pawn clears en passant square', () => {
 
   chess.remove('f5')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing white pawn clears black en passant square 1', () => {
@@ -111,6 +163,10 @@ test('remove - removing white pawn clears black en passant square 1', () => {
 
   chess.remove('g5')
   expect(chess.moves()).not.toContain('gxf6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - removing white pawn clears black en passant square 2', () => {
@@ -120,6 +176,10 @@ test('remove - removing white pawn clears black en passant square 2', () => {
 
   chess.remove('b5')
   expect(chess.moves()).not.toContain('bxc6')
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - reaching initial position deletes setup headers', () => {
@@ -134,6 +194,10 @@ test('remove - reaching initial position deletes setup headers', () => {
   const headers = chess.getHeaders()
   expect(headers['Setup']).toBeUndefined()
   expect(headers['FEN']).toBeUndefined()
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })
 
 test('remove - if a move has been made, reaching initial position does not delete setup headers', () => {
@@ -159,4 +223,8 @@ test('remove - if a move has been made, reaching initial position does not delet
    */
   const headers = chess.getHeaders()
   expect(headers['FEN']).toBeDefined()
+
+  expect(chess.hash().toString(16)).toEqual(
+    new Chess(chess.fen()).hash().toString(16),
+  )
 })

--- a/__tests__/remove.test.ts
+++ b/__tests__/remove.test.ts
@@ -13,27 +13,21 @@ test('remove - returns piece', () => {
   expect(chess.remove('d1')).toEqual({ type: QUEEN, color: WHITE })
   expect(chess.get('d1')).toEqual(undefined)
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - returns undefined for empty square', () => {
   const chess = new Chess()
   expect(chess.remove('e4')).toEqual(undefined)
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - returns undefined for invalid square', () => {
   const chess = new Chess()
   expect(chess.remove('bad_square' as Square)).toEqual(undefined)
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing white kingside rook loses castling right', () => {
@@ -42,9 +36,7 @@ test('remove - removing white kingside rook loses castling right', () => {
   chess.remove('h1')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing white queenside rook loses castling right', () => {
@@ -53,9 +45,7 @@ test('remove - removing white queenside rook loses castling right', () => {
   chess.remove('a1')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing white king loses castling rights', () => {
@@ -76,9 +66,7 @@ test('remove - removing black kingside rook loses castling right', () => {
   chess.remove('h8')
   expect(chess.moves()).not.toContain('O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing black queenside rook loses castling right', () => {
@@ -87,9 +75,7 @@ test('remove - removing black queenside rook loses castling right', () => {
   chess.remove('a8')
   expect(chess.moves()).not.toContain('O-O-O')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing black king loses castling rights', () => {
@@ -112,9 +98,7 @@ test('remove - removing white pawn clears en passant square', () => {
   chess.remove('f4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing black pawn clears white en passant square 1', () => {
@@ -125,9 +109,7 @@ test('remove - removing black pawn clears white en passant square 1', () => {
   chess.remove('g4')
   expect(chess.moves()).not.toContain('gxf3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing black pawn clears white en passant square 2', () => {
@@ -138,9 +120,7 @@ test('remove - removing black pawn clears white en passant square 2', () => {
   chess.remove('b4')
   expect(chess.moves()).not.toContain('bxc3')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing black pawn clears en passant square', () => {
@@ -151,9 +131,7 @@ test('remove - removing black pawn clears en passant square', () => {
   chess.remove('f5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing white pawn clears black en passant square 1', () => {
@@ -164,9 +142,7 @@ test('remove - removing white pawn clears black en passant square 1', () => {
   chess.remove('g5')
   expect(chess.moves()).not.toContain('gxf6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - removing white pawn clears black en passant square 2', () => {
@@ -177,9 +153,7 @@ test('remove - removing white pawn clears black en passant square 2', () => {
   chess.remove('b5')
   expect(chess.moves()).not.toContain('bxc6')
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - reaching initial position deletes setup headers', () => {
@@ -195,9 +169,7 @@ test('remove - reaching initial position deletes setup headers', () => {
   expect(headers['Setup']).toBeUndefined()
   expect(headers['FEN']).toBeUndefined()
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
 
 test('remove - if a move has been made, reaching initial position does not delete setup headers', () => {
@@ -224,7 +196,5 @@ test('remove - if a move has been made, reaching initial position does not delet
   const headers = chess.getHeaders()
   expect(headers['FEN']).toBeDefined()
 
-  expect(chess.hash()).toEqual(
-    new Chess(chess.fen()).hash(),
-  )
+  expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })

--- a/__tests__/zobrist.test.ts
+++ b/__tests__/zobrist.test.ts
@@ -1,4 +1,6 @@
-import { xoroshiro128 } from '../src/chess'
+import { Chess, xoroshiro128 } from '../src/chess'
+
+// Very basic hash tests, more extensive testing is done as part of the move and load pgn tests.
 
 test('rand', () => {
   const rand = xoroshiro128(0xa187eb39cdcaed8f31c4b365b102e01en)
@@ -13,4 +15,21 @@ test('rand', () => {
     '5f29a08525b0575f',
     'f6718179e0f7ba94',
   ])
+})
+
+test('hash is the same for the same position', () => {
+  const a = new Chess()
+  const b = new Chess()
+
+  expect(a.hash()).toEqual(b.hash())
+})
+
+test('hash is different for different positions', () => {
+  const a = new Chess()
+  a.move('e4')
+
+  const b = new Chess()
+  b.move('d4')
+
+  expect(a.hash()).not.toEqual(b.hash())
 })

--- a/__tests__/zobrist.test.ts
+++ b/__tests__/zobrist.test.ts
@@ -1,6 +1,8 @@
-import { rand } from '../src/chess'
+import { xoroshiro128 } from '../src/chess'
 
 test('rand', () => {
+  const rand = xoroshiro128(0xa187eb39cdcaed8f31c4b365b102e01en)
+
   const results = Array.from({ length: 5 }, () => rand().toString(16))
 
   // values take from reference implementation

--- a/__tests__/zobrist.test.ts
+++ b/__tests__/zobrist.test.ts
@@ -1,0 +1,14 @@
+import { rand } from '../src/chess'
+
+test('rand', () => {
+  const results = Array.from({ length: 5 }, () => rand().toString(16))
+
+  // values take from reference implementation
+  expect(results).toEqual([
+    'c9c4700ec0b2a75c',
+    'ce613bcab5ad7ec2',
+    'd4abd9ddcd0a382b',
+    '5f29a08525b0575f',
+    'f6718179e0f7ba94',
+  ])
+})

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -37,23 +37,35 @@ function wrappingMul(x: bigint, y: bigint) {
   return (x * y) & MASK64
 }
 
-let state = 0xa187eb39cdcaed8f31c4b365b102e01en
-
 // xoroshiro128**
-export function rand() {
-  let s0 = BigInt(state & MASK64)
-  let s1 = BigInt((state >> 64n) & MASK64)
+export function xoroshiro128(state: bigint) {
+  return function () {
+    let s0 = BigInt(state & MASK64)
+    let s1 = BigInt((state >> 64n) & MASK64)
 
-  const result = wrappingMul(rotl(wrappingMul(s0, 5n), 7n), 9n)
+    const result = wrappingMul(rotl(wrappingMul(s0, 5n), 7n), 9n)
 
-  s1 ^= s0
-  s0 = (rotl(s0, 24n) ^ s1 ^ (s1 << 16n)) & MASK64
-  s1 = rotl(s1, 37n)
+    s1 ^= s0
+    s0 = (rotl(s0, 24n) ^ s1 ^ (s1 << 16n)) & MASK64
+    s1 = rotl(s1, 37n)
 
-  state = (s1 << 64n) | s0
+    state = (s1 << 64n) | s0
 
-  return result
+    return result
+  }
 }
+
+const rand = xoroshiro128(0xa187eb39cdcaed8f31c4b365b102e01en)
+
+const PIECE_KEYS = Array.from({ length: 2 }, () =>
+  Array.from({ length: 6 }, () => Array.from({ length: 128 }, () => rand())),
+)
+
+const EP_KEYS = Array.from({ length: 8 }, () => rand())
+
+const CASTLING_KEYS = Array.from({ length: 16 }, () => rand())
+
+const SIDE_KEY = rand()
 
 export const WHITE = 'w'
 export const BLACK = 'b'
@@ -707,6 +719,8 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
+  private _hash = 0n
+
   // tracks number of times a position has been seen for repetition checking
   private _positionCount: Record<string, number> = {}
 
@@ -725,6 +739,7 @@ export class Chess {
     this._history = []
     this._comments = {}
     this._header = preserveHeaders ? this._header : { ...HEADER_TEMPLATE }
+    this._hash = this._computeHash()
     this._positionCount = {}
 
     /*
@@ -795,6 +810,7 @@ export class Chess {
     this._halfMoves = parseInt(tokens[4], 10)
     this._moveNumber = parseInt(tokens[5], 10)
 
+    this._hash = this._computeHash()
     this._updateSetup(fen)
     this._incPositionCount(fen)
   }
@@ -900,6 +916,64 @@ export class Chess {
     ].join(' ')
   }
 
+  private _pieceKey(i: number) {
+    if (!this._board[i]) {
+      return 0n
+    }
+
+    const { color, type } = this._board[i]
+
+    const colorIndex = {
+      w: 0,
+      b: 1,
+    }[color]
+
+    const typeIndex = {
+      p: 0,
+      n: 1,
+      b: 2,
+      r: 3,
+      q: 4,
+      k: 5,
+    }[type]
+
+    return PIECE_KEYS[colorIndex][typeIndex][i]
+  }
+
+  private _epKey() {
+    return this._epSquare === EMPTY ? 0n : EP_KEYS[this._epSquare & 7]
+  }
+
+  private _castlingKey() {
+    const index = (this._castling.w >> 5) | (this._castling.b >> 3)
+    return CASTLING_KEYS[index]
+  }
+
+  private _computeHash() {
+    let hash = 0n
+
+    for (let i = Ox88.a8; i <= Ox88.h1; i++) {
+      // did we run off the end of the board
+      if (i & 0x88) {
+        i += 7
+        continue
+      }
+
+      if (this._board[i]) {
+        hash ^= this._pieceKey(i)
+      }
+    }
+
+    hash ^= this._epKey()
+    hash ^= this._castlingKey()
+
+    if (this._turn === 'b') {
+      hash ^= SIDE_KEY
+    }
+
+    return hash
+  }
+
   /*
    * Called when the initial board setup is changed with put() or remove().
    * modifies the SetUp and FEN properties of the header object. If the FEN
@@ -965,6 +1039,12 @@ export class Chess {
     return false
   }
 
+  private _set(sq: number, piece: Piece) {
+    this._hash ^= this._pieceKey(sq)
+    this._board[sq] = piece
+    this._hash ^= this._pieceKey(sq)
+  }
+
   private _put(
     { type, color }: { type: PieceSymbol; color: Color },
     square: Square,
@@ -996,7 +1076,7 @@ export class Chess {
       this._kings[currentPieceOnSquare.color] = EMPTY
     }
 
-    this._board[sq] = { type: type as PieceSymbol, color: color as Color }
+    this._set(sq, { type: type as PieceSymbol, color: color as Color })
 
     if (type === KING) {
       this._kings[color] = sq
@@ -1005,9 +1085,14 @@ export class Chess {
     return true
   }
 
+  private _clear(sq: number) {
+    this._hash ^= this._pieceKey(sq)
+    delete this._board[sq]
+  }
+
   remove(square: Square): Piece | undefined {
     const piece = this.get(square)
-    delete this._board[Ox88[square]]
+    this._clear(Ox88[square])
     if (piece && piece.type === KING) {
       this._kings[piece.color] = EMPTY
     }
@@ -1020,6 +1105,8 @@ export class Chess {
   }
 
   private _updateCastlingRights() {
+    this._hash ^= this._castlingKey()
+
     const whiteKingInPlace =
       this._board[Ox88.e1]?.type === KING &&
       this._board[Ox88.e1]?.color === WHITE
@@ -1058,6 +1145,8 @@ export class Chess {
     ) {
       this._castling.b &= ~BITS.KSIDE_CASTLE
     }
+
+    this._hash ^= this._castlingKey()
   }
 
   private _updateEnPassantSquare() {
@@ -1075,6 +1164,7 @@ export class Chess {
       this._board[currentSquare]?.color !== swapColor(this._turn) ||
       this._board[currentSquare]?.type !== PAWN
     ) {
+      this._hash ^= this._epKey()
       this._epSquare = EMPTY
       return
     }
@@ -1085,6 +1175,7 @@ export class Chess {
       this._board[square]?.type === PAWN
 
     if (!attackers.some(canCapture)) {
+      this._hash ^= this._epKey()
       this._epSquare = EMPTY
     }
   }
@@ -1182,6 +1273,10 @@ export class Chess {
   private _isKingAttacked(color: Color): boolean {
     const square = this._kings[color]
     return square === -1 ? false : this._attacked(swapColor(color), square)
+  }
+
+  hash(): bigint {
+    return this._hash
   }
 
   isAttacked(square: Square, attackedBy: Color): boolean {
@@ -1622,26 +1717,42 @@ export class Chess {
     })
   }
 
+  private _movePiece(from: number, to: number) {
+    this._hash ^= this._pieceKey(from)
+
+    this._board[to] = this._board[from]
+    delete this._board[from]
+
+    this._hash ^= this._pieceKey(to)
+  }
+
   private _makeMove(move: InternalMove) {
     const us = this._turn
     const them = swapColor(us)
     this._push(move)
 
-    this._board[move.to] = this._board[move.from]
-    delete this._board[move.from]
+    this._hash ^= this._epKey()
+    this._hash ^= this._castlingKey()
+
+    if (move.captured) {
+      this._hash ^= this._pieceKey(move.to)
+    }
+
+    this._movePiece(move.from, move.to)
 
     // if ep capture, remove the captured pawn
     if (move.flags & BITS.EP_CAPTURE) {
       if (this._turn === BLACK) {
-        delete this._board[move.to - 16]
+        this._clear(move.to - 16)
       } else {
-        delete this._board[move.to + 16]
+        this._clear(move.to + 16)
       }
     }
 
     // if pawn promotion, replace with new piece
     if (move.promotion) {
-      this._board[move.to] = { type: move.promotion, color: us }
+      this._clear(move.to)
+      this._set(move.to, { type: move.promotion, color: us })
     }
 
     // if we moved the king
@@ -1652,13 +1763,11 @@ export class Chess {
       if (move.flags & BITS.KSIDE_CASTLE) {
         const castlingTo = move.to - 1
         const castlingFrom = move.to + 1
-        this._board[castlingTo] = this._board[castlingFrom]
-        delete this._board[castlingFrom]
+        this._movePiece(castlingFrom, castlingTo)
       } else if (move.flags & BITS.QSIDE_CASTLE) {
         const castlingTo = move.to + 1
         const castlingFrom = move.to - 2
-        this._board[castlingTo] = this._board[castlingFrom]
-        delete this._board[castlingFrom]
+        this._movePiece(castlingFrom, castlingTo)
       }
 
       // turn off castling
@@ -1691,12 +1800,30 @@ export class Chess {
       }
     }
 
+    this._hash ^= this._castlingKey()
+
     // if big pawn move, update the en passant square
     if (move.flags & BITS.BIG_PAWN) {
+      let epSquare
+
       if (us === BLACK) {
-        this._epSquare = move.to - 16
+        epSquare = move.to - 16
       } else {
-        this._epSquare = move.to + 16
+        epSquare = move.to + 16
+      }
+
+      if (
+        (!((move.to - 1) & 0x88) &&
+          this._board[move.to - 1]?.type === PAWN &&
+          this._board[move.to - 1]?.color === them) ||
+        (!((move.to + 1) & 0x88) &&
+          this._board[move.to + 1]?.type === PAWN &&
+          this._board[move.to + 1]?.color === them)
+      ) {
+        this._epSquare = epSquare
+        this._hash ^= this._epKey()
+      } else {
+        this._epSquare = EMPTY
       }
     } else {
       this._epSquare = EMPTY
@@ -1716,6 +1843,7 @@ export class Chess {
     }
 
     this._turn = them
+    this._hash ^= SIDE_KEY
   }
 
   undo(): Move | null {
@@ -1734,6 +1862,9 @@ export class Chess {
       return null
     }
 
+    this._hash ^= this._epKey()
+    this._hash ^= this._castlingKey()
+
     const move = old.move
 
     this._kings = old.kings
@@ -1743,12 +1874,20 @@ export class Chess {
     this._halfMoves = old.halfMoves
     this._moveNumber = old.moveNumber
 
+    this._hash ^= this._epKey()
+    this._hash ^= this._castlingKey()
+    this._hash ^= SIDE_KEY
+
     const us = this._turn
     const them = swapColor(us)
 
-    this._board[move.from] = this._board[move.to]
-    this._board[move.from].type = move.piece // to undo any promotions
-    delete this._board[move.to]
+    this._movePiece(move.to, move.from)
+
+    // to undo any promotions
+    if (move.piece) {
+      this._clear(move.from)
+      this._set(move.from, { type: move.piece, color: us })
+    }
 
     if (move.captured) {
       if (move.flags & BITS.EP_CAPTURE) {
@@ -1759,10 +1898,10 @@ export class Chess {
         } else {
           index = move.to + 16
         }
-        this._board[index] = { type: PAWN, color: them }
+        this._set(index, { type: PAWN, color: them })
       } else {
         // regular capture
-        this._board[move.to] = { type: move.captured, color: them }
+        this._set(move.to, { type: move.captured, color: them })
       }
     }
 
@@ -1775,9 +1914,7 @@ export class Chess {
         castlingTo = move.to - 2
         castlingFrom = move.to + 1
       }
-
-      this._board[castlingTo] = this._board[castlingFrom]
-      delete this._board[castlingFrom]
+      this._movePiece(castlingFrom, castlingTo)
     }
 
     return move

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -27,6 +27,34 @@
 
 import { parse } from './pgn'
 
+const MASK64 = 0xffffffffffffffffn
+
+function rotl(x: bigint, k: bigint): bigint {
+  return ((x << k) | (x >> (64n - k))) & 0xffffffffffffffffn
+}
+
+function wrappingMul(x: bigint, y: bigint) {
+  return (x * y) & MASK64
+}
+
+let state = 0xa187eb39cdcaed8f31c4b365b102e01en
+
+// xoroshiro128**
+export function rand() {
+  let s0 = BigInt(state & MASK64)
+  let s1 = BigInt((state >> 64n) & MASK64)
+
+  const result = wrappingMul(rotl(wrappingMul(s0, 5n), 7n), 9n)
+
+  s1 ^= s0
+  s0 = (rotl(s0, 24n) ^ s1 ^ (s1 << 16n)) & MASK64
+  s1 = rotl(s1, 37n)
+
+  state = (s1 << 64n) | s0
+
+  return result
+}
+
 export const WHITE = 'w'
 export const BLACK = 'b'
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1267,8 +1267,8 @@ export class Chess {
     return square === -1 ? false : this._attacked(swapColor(color), square)
   }
 
-  hash(): bigint {
-    return this._hash
+  hash(): string {
+    return this._hash.toString(16)
   }
 
   isAttacked(square: Square, attackedBy: Color): boolean {
@@ -1353,7 +1353,7 @@ export class Chess {
   }
 
   isThreefoldRepetition(): boolean {
-    return this._getPositionCount(this.hash()) >= 3
+    return this._getPositionCount(this._hash) >= 3
   }
 
   isDrawByFiftyMoves(): boolean {


### PR DESCRIPTION
Adds a new method call hash() which will return a 64bit bigint.

* Benchmark performance about the same, maybe very slightly faster.
* The internal ep square is now only set if there a pawn able to capture next move (does not check full legality, checks etc)
* The threefold repetition tracking is now done with a map of hashes 
* Hash integrity is mainly checked during the move and load pgn tests
* Standard zobrist implementation, with included stable/seeded rng() 
