### PR TITLE
Fix parsing of suffix annotations

### DIFF
--- a/src/pgn.peggy
+++ b/src/pgn.peggy
@@ -89,7 +89,7 @@ san "standard algebraic notation"
 	= $(("O-O-O" / "O-O" / "0-0-0" / "0-0" / [a-zA-Z][a-zA-Z1-8-=]+) [+#]?)
 
 suffixAnnotation "suffix annotation"
-	= [!?] |1..2|
+	= $[!?]|1..2|
 
 nag "NAG"
 	= _ '$' nag:$[0-9]+ { return nag }


### PR DESCRIPTION
Stops two character suffixes (e.g. !!) from being interpreted as an array of characters rather than a string.