### PR TITLE
Improve Draw Rule Handling

### DIFF
--- a/__tests__/can-threefold-repetition.test.ts
+++ b/__tests__/can-threefold-repetition.test.ts
@@ -2,29 +2,29 @@ import { Chess } from '../src/chess'
 import { split } from './utils'
 import { expect, test } from 'vitest'
 
-test('isThreefoldRepetition', () => {
+test('canThreefoldRepetition', () => {
   /* Fischer - Petrosian, Buenos Aires, 1971 */
   const fen = '8/pp3p1k/2p2q1p/3r1P2/5R2/7P/P1P1QP2/7K b - - 2 30'
   const moves = split('Qe5 Qh5 Qf6 Qe2 Re5 Qd3 Rd5 Qe2')
 
   const chess = new Chess(fen)
   moves.forEach((move) => {
-    expect(chess.isThreefoldRepetition()).toBe(false)
+    expect(chess.canThreefoldRepetition()).toBe(false)
     chess.move(move)
   })
-  expect(chess.isThreefoldRepetition()).toBe(true)
+  expect(chess.canThreefoldRepetition()).toBe(true)
   chess.move('a6')
-  expect(chess.isThreefoldRepetition()).toBe(false)
+  expect(chess.canThreefoldRepetition()).toBe(false)
 })
 
-test('isThreefoldRepetition - 2', () => {
+test('canThreefoldRepetition - 2', () => {
   const moves = 'Nf3 Nf6 Ng1 Ng8 Nf3 Nf6 Ng1 Ng8'.split(/\s+/)
   const chess = new Chess()
   moves.forEach((move) => {
-    expect(chess.isThreefoldRepetition()).toBe(false)
+    expect(chess.canThreefoldRepetition()).toBe(false)
     chess.move(move)
   })
-  expect(chess.isThreefoldRepetition()).toBe(true)
+  expect(chess.canThreefoldRepetition()).toBe(true)
   chess.move('e4')
-  expect(chess.isThreefoldRepetition()).toBe(false)
+  expect(chess.canThreefoldRepetition()).toBe(false)
 })

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1377,6 +1377,10 @@ export class Chess {
   }
 
   isThreefoldRepetition(): boolean {
+    return this._getPositionCount(this._hash) >= 3 && this._isManuallyDrawn
+  }
+
+  canThreefoldRepetition(): boolean {
     return this._getPositionCount(this._hash) >= 3
   }
 
@@ -1403,7 +1407,6 @@ export class Chess {
       this.isDrawByFiftyMoves() ||
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
-      this.isThreefoldRepetition() ||
       this._isManuallyDrawn
     )
   }

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1409,7 +1409,7 @@ export class Chess {
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
       this._isManuallyDrawn ||
-      this.canThreefoldRepetition() && this._nullMovesCount >= 6 // 6 null moves in a row
+      (this.canThreefoldRepetition() && this._nullMovesCount >= 6) // 6 null moves in a row
     )
   }
 
@@ -1763,7 +1763,7 @@ export class Chess {
     this._makeMove(moveObj)
     this._incPositionCount()
 
-    if(prettyMove.san === '--') {
+    if (prettyMove.san === '--') {
       this._nullMovesCount++
     } else {
       this._nullMovesCount = 0

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1381,6 +1381,10 @@ export class Chess {
     return this._getPositionCount(this._hash) >= 3 && this._isManuallyDrawn
   }
 
+  isFivefoldRepetition(): boolean {
+    return this._getPositionCount(this._hash) >= 5
+  }
+
   canThreefoldRepetition(): boolean {
     return this._getPositionCount(this._hash) >= 3
   }
@@ -1406,6 +1410,7 @@ export class Chess {
   isDraw(): boolean {
     return (
       this.isDrawByFiftyMoves() ||
+      this.isFivefoldRepetition() ||
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
       this._isManuallyDrawn ||

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -727,6 +727,7 @@ export class Chess {
   private _positionCount = new Map<bigint, number>()
 
   private _isManuallyDrawn = false
+  private _nullMovesCount = 0
 
   constructor(fen = DEFAULT_POSITION, { skipValidation = false } = {}) {
     this._comments = {}
@@ -1407,7 +1408,8 @@ export class Chess {
       this.isDrawByFiftyMoves() ||
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
-      this._isManuallyDrawn
+      this._isManuallyDrawn ||
+      this.canThreefoldRepetition() && this._nullMovesCount >= 6 // 6 null moves in a row
     )
   }
 
@@ -1760,6 +1762,13 @@ export class Chess {
 
     this._makeMove(moveObj)
     this._incPositionCount()
+
+    if(prettyMove.san === '--') {
+      this._nullMovesCount++
+    } else {
+      this._nullMovesCount = 0
+    }
+
     return prettyMove
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1404,8 +1404,6 @@ export class Chess {
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
       this.isThreefoldRepetition() ||
-      this.isDrawByFiftyMoves() ||
-      this.isDrawBySeventyFiveMoves() ||
       this._isManuallyDrawn
     )
   }

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -726,6 +726,8 @@ export class Chess {
   // tracks number of times a position has been seen for repetition checking
   private _positionCount = new Map<bigint, number>()
 
+  private _isManuallyDrawn = false
+
   constructor(fen = DEFAULT_POSITION, { skipValidation = false } = {}) {
     this._comments = {}
     this._suffixes = {}
@@ -1379,7 +1381,21 @@ export class Chess {
   }
 
   isDrawByFiftyMoves(): boolean {
-    return this._halfMoves >= 100 // 50 moves per side = 100 half moves
+    return this._halfMoves >= 100 && this._isManuallyDrawn // 50 moves per side = 100 half moves
+  }
+
+  isDrawBySeventyFiveMoves(): boolean {
+    return this._halfMoves >= 150 // 75 moves per side = 150 half moves
+  }
+
+  canDrawByFiftyMoves(): boolean {
+    return this._halfMoves >= 100 && this._isManuallyDrawn // 50 moves per side = 100 half moves
+  }
+
+  draw(): boolean {
+    if (this.isGameOver()) return false
+    this._isManuallyDrawn = true
+    return true
   }
 
   isDraw(): boolean {
@@ -1387,7 +1403,10 @@ export class Chess {
       this.isDrawByFiftyMoves() ||
       this.isStalemate() ||
       this.isInsufficientMaterial() ||
-      this.isThreefoldRepetition()
+      this.isThreefoldRepetition() ||
+      this.isDrawByFiftyMoves() ||
+      this.isDrawBySeventyFiveMoves() ||
+      this._isManuallyDrawn
     )
   }
 


### PR DESCRIPTION
> [!IMPORTANT]  
> The changes applied by this PR **can** be described as **BREAKING CHANGES** as contains changes to the  _public API_ as descibed in the **_Changes_** sections

### Overview  
This PR refines the implementation of draw conditions to make them more compliant with official FIDE chess rules.

### Changes  
- **Manual Drawing**
  - Added `draw()` method to allow players to manually claim a draw.

- **Fifty-Move Rule**
   - Split logic into:
    - `canDrawByFiftyMoves()` → detects when the position qualifies for a draw claim.
    - `isDrawByFiftyMoves()` → requires explicit claim (`_isManuallyDrawn`).
  
- **Threefold Repetition**
  - Split logic into:
    - `canThreefoldRepetition()` → detects when the position qualifies for a claim.
    - `isThreefoldRepetition()` → requires explicit claim (`_isManuallyDrawn`).
  - Updated tests (`can-threefold-repetition.test.ts`) to reflect new semantics.
  
- **Null Move Handling**
  - At an high-level it does not change, only the implementation changes.
  - Added `_nullMovesCount` to track consecutive null moves ( with `"--"` SAN).
  - Game considered drawn if `canThreefoldRepetition()` **and** 6 consecutive null moves occur.

> [!NOTE]  
> The handling of **manual draws** must be implemented by the developer using the library, for example:  
> - For draws not triggered by fifty-move or threefold repetition rules, the developer should ensure that **both players agree** to a draw.  
> - For draws due to fifty-move or threefold repetition, it is sufficient that **only one player requests the draw** for it to be valid.

### Why  
- Aligns draw logic with **FIDE chess rules** (distinction between automatic and claimable draws).  

### Tests  
- Updated and renamed tests for `canThreefoldRepetition()`.  
- Confirmed compliance with all tests.  
