### PR TITLE
Ignore invalid castling rights

### DIFF
--- a/__tests__/load.test.ts
+++ b/__tests__/load.test.ts
@@ -1,5 +1,13 @@
-import { Chess, DEFAULT_POSITION, SEVEN_TAG_ROSTER } from '../src/chess'
 import { expect, test } from 'vitest'
+import {
+  BLACK,
+  Chess,
+  DEFAULT_POSITION,
+  KING,
+  QUEEN,
+  SEVEN_TAG_ROSTER,
+  WHITE,
+} from '../src/chess'
 
 test('load - default position', () => {
   const chess = new Chess()
@@ -54,6 +62,66 @@ test('load - missing FEN tokens (no castling rights, ep square, or move numbers)
   const chess = new Chess()
   const fen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'
   expect(() => chess.load(fen)).not.toThrow()
+})
+
+test('load - full castling rights but white king moved', () => {
+  const chess = new Chess()
+  const fen = 'r3k2r/8/8/8/8/8/8/R2K3R w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(WHITE)).toEqual({
+    [KING]: false,
+    [QUEEN]: false,
+  })
+})
+
+test('load - full castling rights but white kingside rook moved', () => {
+  const chess = new Chess()
+  const fen = 'r3k2r/8/8/8/8/8/8/R3K1R1 w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(WHITE)).toEqual({
+    [KING]: false,
+    [QUEEN]: true,
+  })
+})
+
+test('load - full castling rights but white queenside rook moved', () => {
+  const chess = new Chess()
+  const fen = 'r3k2r/8/8/8/8/8/8/1R2K2R w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(WHITE)).toEqual({
+    [KING]: true,
+    [QUEEN]: false,
+  })
+})
+
+test('load - full castling rights but black king moved', () => {
+  const chess = new Chess()
+  const fen = 'r2k3r/8/8/8/8/8/8/R3K2R w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(BLACK)).toEqual({
+    [KING]: false,
+    [QUEEN]: false,
+  })
+})
+
+test('load - full castling rights but black kingside rook moved', () => {
+  const chess = new Chess()
+  const fen = 'r3k1r1/8/8/8/8/8/8/R3K2R w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(BLACK)).toEqual({
+    [KING]: false,
+    [QUEEN]: true,
+  })
+})
+
+test('load - full castling rights but black queenside rook moved', () => {
+  const chess = new Chess()
+  const fen = '1r2k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1'
+  chess.load(fen)
+  expect(chess.getCastlingRights(BLACK)).toEqual({
+    [KING]: true,
+    [QUEEN]: false,
+  })
 })
 
 test('load - preserveHeaders = false', () => {

--- a/__tests__/regression.test.ts
+++ b/__tests__/regression.test.ts
@@ -33,25 +33,25 @@ describe('Regression Tests', () => {
     const chess = new Chess()
     const pgn = [
       '[SetUp "1"]',
-      '[FEN "7k/5K2/4R3/8/8/8/8/8 w KQkq - 0 1"]',
+      '[FEN "7k/5K2/4R3/8/8/8/8/8 w - - 0 1"]',
       '',
       '1. Rh6#',
     ]
     chess.loadPgn(pgn.join('\n'))
-    expect(chess.fen()).toBe('7k/5K2/7R/8/8/8/8/8 b KQkq - 1 1')
+    expect(chess.fen()).toBe('7k/5K2/7R/8/8/8/8/8 b - - 1 1')
   })
 
   it('Github Issue #85 (black) - SetUp and FEN should be accepted in loadPgn', () => {
     const chess = new Chess()
     const pgn = [
       '[SetUp "1"]',
-      '[FEN "r4r1k/1p4b1/3p3p/5qp1/1RP5/6P1/3NP3/2Q2RKB b KQkq - 0 1"]',
+      '[FEN "r4r1k/1p4b1/3p3p/5qp1/1RP5/6P1/3NP3/2Q2RKB b - - 0 1"]',
       '',
       '1. ... Qc5+',
     ]
     chess.loadPgn(pgn.join('\n'))
     expect(chess.fen()).toBe(
-      'r4r1k/1p4b1/3p3p/2q3p1/1RP5/6P1/3NP3/2Q2RKB w KQkq - 1 2',
+      'r4r1k/1p4b1/3p3p/2q3p1/1RP5/6P1/3NP3/2Q2RKB w - - 1 2',
     )
   })
 
@@ -302,5 +302,10 @@ describe('Regression Tests', () => {
     chess.loadPgn(pgn)
 
     expect(chess.moveNumber()).toBe(31)
+  })
+
+  it('Github Issue #552 - ignore invalid castling rights', () => {
+    const chess = new Chess('kb4r1/p2n3P/1PP5/1P6/8/8/6p1/R3KR2 b KQkq - 0 19')
+    expect(chess.isGameOver()).toBe(false) // this was crashing due to invalid castling moves being generated
   })
 })

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -811,6 +811,8 @@ export class Chess {
       this._castling.b |= BITS.QSIDE_CASTLE
     }
 
+    this._updateCastlingRights()
+
     this._epSquare = tokens[3] === '-' ? EMPTY : Ox88[tokens[3] as Square]
     this._fenEpSquare = this._epSquare
     this._halfMoves = parseInt(tokens[4], 10)


### PR DESCRIPTION
Fixes #552. Turns out that the move generator was generating invalid castling moves due to incorrect castling rights in the FEN.
