### PR TITLE
Fix: handle invalid FEN when side to move is already delivering check

### DIFF
--- a/__tests__/put.test.ts
+++ b/__tests__/put.test.ts
@@ -154,7 +154,7 @@ test('put - occupying white en passant square clears it', () => {
     'rnbqkbnr/pppppp1p/8/8/3PPPp1/8/PPP3PP/RNBQKBNR b KQkq f3 0 3',
   )
 
-  chess.put({ type: KNIGHT, color: BLACK }, 'f3')
+  chess.put({ type: BISHOP, color: BLACK }, 'f3')
   expect(chess.moves()).not.toContain('gxf3')
 
   expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
@@ -184,11 +184,11 @@ test('put - replacing black pawn clears white en passant square 1', () => {
 
 test('put - replacing black pawn clears white en passant square 2', () => {
   const chess = new Chess(
-    'rnbqkbnr/p1pppppp/8/8/1pPPP3/8/PP3PPP/RNBQKBNR b KQkq c3 0 3',
+    'rnbqkbnr/p1pppppp/8/8/2pPPP2/8/PP3PPP/RNBQKBNR b KQkq d3 0 3',
   )
 
-  chess.put({ type: BISHOP, color: BLACK }, 'b4')
-  expect(chess.moves()).not.toContain('bxc3')
+  chess.put({ type: KNIGHT, color: BLACK }, 'c4')
+  expect(chess.moves()).not.toContain('cxd3')
 
   expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })
@@ -209,7 +209,7 @@ test('put - occupying black en passant square clears it', () => {
     'rnbqkbnr/pppp2pp/8/4ppP1/8/8/PPPPPP1P/RNBQKBNR w KQkq f6 0 3',
   )
 
-  chess.put({ type: KNIGHT, color: WHITE }, 'f6')
+  chess.put({ type: BISHOP, color: WHITE }, 'f6')
   expect(chess.moves()).not.toContain('gxf6')
 
   expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
@@ -239,11 +239,11 @@ test('put - replacing white pawn clears black en passant square 1', () => {
 
 test('put - replacing white pawn clears black en passant square 2', () => {
   const chess = new Chess(
-    'rnbqkbnr/pp2pppp/8/1Ppp4/8/8/P1PPPPPP/RNBQKBNR w KQkq c6 0 3',
+    'rnbqkbnr/pp2pppp/8/2Ppp3/8/8/P1PPPPPP/RNBQKBNR w KQkq d6 0 3',
   )
 
-  chess.put({ type: BISHOP, color: WHITE }, 'b5')
-  expect(chess.moves()).not.toContain('bxc6')
+  chess.put({ type: BISHOP, color: WHITE }, 'c5')
+  expect(chess.moves()).not.toContain('cxd6')
 
   expect(chess.hash()).toEqual(new Chess(chess.fen()).hash())
 })

--- a/__tests__/validate_fen.test.ts
+++ b/__tests__/validate_fen.test.ts
@@ -516,6 +516,11 @@ test.each([
     fen: '3r1r2/3P2pk/1p1R3p/1Bp2p2/6q1/4Q3/PP3P1P/7K w - - 4 30',
     ok: true,
   },
+  // Test cases where side to move is in check
+  {
+    fen: '1n6/8/2Q5/1rK5/8/8/8/5k2 b - - 0 1',
+    ok: false,
+  },
 ])("validateFen $# '$fen' (expected: '$ok')", ({ fen, ok }) => {
   expect(validateFen(fen)).toMatchObject({ ok })
 })

--- a/__tests__/validate_fen.test.ts
+++ b/__tests__/validate_fen.test.ts
@@ -516,9 +516,13 @@ test.each([
     fen: '3r1r2/3P2pk/1p1R3p/1Bp2p2/6q1/4Q3/PP3P1P/7K w - - 4 30',
     ok: true,
   },
-  // Test cases where side to move is in check
+  // Test cases where side to move is already delivering check
   {
     fen: '1n6/8/2Q5/1rK5/8/8/8/5k2 b - - 0 1',
+    ok: false,
+  },
+  {
+    fen: '4k3/8/8/1B3N2/8/2q5/8/4K3 w - - 0 1',
     ok: false,
   },
 ])("validateFen $# '$fen' (expected: '$ok')", ({ fen, ok }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4312,27 +4312,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -594,16 +594,12 @@ export function validateFen(fen: string): { ok: boolean; error?: string } {
   }
 
   // 12th criterion: is side to move already delivering check?
-  console.log(tokens[1], swapColor(tokens[1] as Color))
-
   const tokensTemp = tokens.slice()
   tokensTemp[1] = swapColor(tokens[1] as Color)
   const tempFen = tokensTemp.join(' ') // swap the side to move
 
-  console.log(tempFen)
   const tempChess = new Chess(tempFen, { skipValidation: true })
   if (tempChess.inCheck()) {
-    console.log(tempChess.inCheck())
     return {
       ok: false,
       error: 'Invalid FEN: side to move is already delivering check',
@@ -2814,6 +2810,3 @@ export class Chess {
     return this._moveNumber
   }
 }
-
-const testFen = 'r3k2r/8/p4p2/3p2p1/4b3/2R2PP1/P6P/4R1K1 b kq - 0 27'
-console.log(validateFen(testFen))

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -593,6 +593,23 @@ export function validateFen(fen: string): { ok: boolean; error?: string } {
     }
   }
 
+  // 12th criterion: is side to move already delivering check?
+  console.log(tokens[1], swapColor(tokens[1] as Color))
+
+  const tokensTemp = tokens.slice()
+  tokensTemp[1] = swapColor(tokens[1] as Color)
+  const tempFen = tokensTemp.join(' ') // swap the side to move
+
+  console.log(tempFen)
+  const tempChess = new Chess(tempFen, { skipValidation: true })
+  if (tempChess.inCheck()) {
+    console.log(tempChess.inCheck())
+    return {
+      ok: false,
+      error: 'Invalid FEN: side to move is already delivering check',
+    }
+  }
+
   return { ok: true }
 }
 
@@ -2797,3 +2814,6 @@ export class Chess {
     return this._moveNumber
   }
 }
+
+const testFen = 'r3k2r/8/p4p2/3p2p1/4b3/2R2PP1/P6P/4R1K1 b kq - 0 27'
+console.log(validateFen(testFen))


### PR DESCRIPTION
Fixes #558 

This PR updates the validateFen() function to correctly handle cases where the side to move is already delivering check.

### Changes
* Updated `validateFen()` logic to detect when the side to move is already delivering check
```javascript
export function validateFen(fen: string): { ok: boolean; error?: string } {
  
  // .. Rest of code

  // 12th criterion: is side to move already delivering check?
  const tokensTemp = tokens.slice()
  tokensTemp[1] = swapColor(tokens[1] as Color)
  const tempFen = tokensTemp.join(' ') // swap the side to move

  const tempChess = new Chess(tempFen, { skipValidation: true })
  if (tempChess.inCheck()) {
    return {
      ok: false,
      error: 'Invalid FEN: side to move is already delivering check',
    }
  }

  return { ok: true }
}
```
* Added and updated related test cases
  * Two testcases were added in `validate_fen.test.ts`.
  * Four testcases in `put.test.ts` were updated because they triggered the invalid FEN error. Please check if the modified testcases still reflect the original intention.
`put - occupying white en passant square clears it`
`put - replacing black pawn clears white en passant square 2`
`put - occupying black en passant square clears it`
`put - replacing white pawn clears black en passant square 2`

