### PR TITLE
Add glyphs support

### DIFF
--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -1,0 +1,201 @@
+import { Chess, Glyph } from '../src/chess'
+import { describe, expect, it } from 'vitest'
+
+describe('Glyph Support', () => {
+  it('captures multiple NAGs and converts to glyphs', () => {
+    const chess = new Chess()
+    const pgn =
+      '1. e4 $1 {Great move} ' +
+      'e5 $6 {Questionable} ' +
+      '2. Nf3 $14 Nc6 $10 *'
+
+    chess.loadPgn(pgn)
+
+    const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    const fen2 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    const fen3 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
+    const fen4 = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
+
+    expect(chess.fen()).toEqual(fen4)
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: fen1,
+      comment: 'Great move',
+    })
+    expect(comments).toContainEqual({
+      fen: fen2,
+      comment: 'Questionable',
+    })
+    expect(comments).toContainEqual({
+      fen: fen3,
+      glyph: '⩲', // $14 -> White is slightly better
+    })
+    expect(comments).toContainEqual({
+      fen: fen4,
+      glyph: '=', // $10 -> Equal position
+    })
+  })
+
+  it('handles multiple NAGs by using first valid glyph', () => {
+    const chess = new Chess()
+    const pgn = '1. e4 $1 $14 $99 $10 *' // Mix of invalid and valid NAGs
+
+    chess.loadPgn(pgn)
+
+    const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    const comments = chess.getComments()
+
+    expect(comments).toContainEqual({
+      fen: fen1,
+      glyph: '⩲', // Should use $14 (first valid glyph) not $10
+    })
+  })
+
+  it('manually set glyph with validation', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const currentFen = chess.fen()
+
+    // Valid glyph
+    chess.setGlyph('±')
+    expect(chess.getGlyph()).toEqual('±')
+    expect(chess.getGlyph(currentFen)).toEqual('±')
+
+    // Invalid glyph should throw
+    expect(() => chess.setGlyph('invalid' as never)).toThrow('Invalid glyph: invalid')
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: currentFen,
+      glyph: '±',
+    })
+  })
+
+  it('remove glyph functionality', () => {
+    const chess = new Chess()
+    chess.move('e4')
+
+    // Set a glyph
+    chess.setGlyph('∞')
+    expect(chess.getGlyph()).toEqual('∞')
+
+    // Remove it
+    const removed = chess.removeGlyph()
+    expect(removed).toEqual('∞')
+    expect(chess.getGlyph()).toBeUndefined()
+
+    // Remove non-existent should return undefined
+    const removedAgain = chess.removeGlyph()
+    expect(removedAgain).toBeUndefined()
+
+    // Comments should be empty after removal
+    expect(chess.getComments()).toEqual([])
+  })
+
+  it('glyph with specific FEN', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const fen1 = chess.fen()
+    chess.move('e5')
+    const fen2 = chess.fen()
+
+    // Set glyph for previous position
+    chess.setGlyph('→', fen1)
+    expect(chess.getGlyph(fen1)).toEqual('→')
+    expect(chess.getGlyph(fen2)).toBeUndefined()
+    expect(chess.getGlyph()).toBeUndefined() // Current position has no glyph
+
+    // Remove glyph by FEN
+    const removed = chess.removeGlyph(fen1)
+    expect(removed).toEqual('→')
+    expect(chess.getGlyph(fen1)).toBeUndefined()
+  })
+
+  it('integration with comments and suffixes', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const currentFen = chess.fen()
+
+    // Set all three types of annotations
+    chess.setComment('Excellent opening')
+    chess.setSuffixAnnotation('!!')
+    chess.setGlyph('⩲')
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: currentFen,
+      comment: 'Excellent opening',
+      suffixAnnotation: '!!',
+      glyph: '⩲',
+    })
+  })
+
+  it('reset clears all glyphs', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    chess.setGlyph('±')
+    chess.move('e5')
+    chess.setGlyph('∓')
+
+    expect(chess.getComments()).toHaveLength(2)
+
+    chess.reset()
+    expect(chess.getComments()).toEqual([])
+    expect(chess.getGlyph()).toBeUndefined()
+  })
+
+  it('all supported lichess glyphs', () => {
+    const chess = new Chess()
+    const supportedGlyphs: Glyph[] = [
+      '□', // Only move
+      '⨀', // Zugzwang
+      '=', // Equal position
+      '∞', // Unclear position
+      '⩲', // White is slightly better
+      '⩱', // Black is slightly better
+      '±', // White is better
+      '∓', // Black is better
+      '+−', // White is winning
+      '-+', // Black is winning
+      'N', // Novelty
+      '↑↑', // Development
+      '↑', // Initiative
+      '→', // Attack
+      '⇆', // Counterplay
+      '⊕', // Time trouble
+      '=∞', // With compensation
+      '∆', // With the idea
+    ]
+
+    // Test each glyph can be set and retrieved
+    supportedGlyphs.forEach(glyph => {
+      chess.setGlyph(glyph)
+      expect(chess.getGlyph()).toEqual(glyph)
+    })
+  })
+
+  it('PGN with NAGs mapped to glyphs', () => {
+    const chess = new Chess()
+    const pgn = `
+      1. e4 $16 $132 e5 $15
+      2. Nf3 $36 Nc6 $140
+      3. Bc4 $40 Be7 $44 *
+    `
+
+    chess.loadPgn(pgn)
+
+    const comments = chess.getComments()
+
+    // Find entries with glyphs
+    const glyphEntries = comments.filter(entry => entry.glyph)
+
+    expect(glyphEntries).toHaveLength(6)
+    expect(glyphEntries.map(e => e.glyph)).toContain('±') // $16
+    expect(glyphEntries.map(e => e.glyph)).toContain('⩱') // $15
+    expect(glyphEntries.map(e => e.glyph)).toContain('↑') // $36
+    expect(glyphEntries.map(e => e.glyph)).toContain('∆') // $140
+    expect(glyphEntries.map(e => e.glyph)).toContain('→') // $40
+    expect(glyphEntries.map(e => e.glyph)).toContain('=∞') // $44
+  })
+})

--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -13,8 +13,10 @@ describe('Glyph Support', () => {
 
     const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
     const fen2 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
-    const fen3 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
-    const fen4 = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
+    const fen3 =
+      'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
+    const fen4 =
+      'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
 
     expect(chess.fen()).toEqual(fen4)
 
@@ -63,7 +65,9 @@ describe('Glyph Support', () => {
     expect(chess.getGlyph(currentFen)).toEqual('±')
 
     // Invalid glyph should throw
-    expect(() => chess.setGlyph('invalid' as never)).toThrow('Invalid glyph: invalid')
+    expect(() => chess.setGlyph('invalid' as never)).toThrow(
+      'Invalid glyph: invalid',
+    )
 
     const comments = chess.getComments()
     expect(comments).toContainEqual({
@@ -169,7 +173,7 @@ describe('Glyph Support', () => {
     ]
 
     // Test each glyph can be set and retrieved
-    supportedGlyphs.forEach(glyph => {
+    supportedGlyphs.forEach((glyph) => {
       chess.setGlyph(glyph)
       expect(chess.getGlyph()).toEqual(glyph)
     })
@@ -188,14 +192,14 @@ describe('Glyph Support', () => {
     const comments = chess.getComments()
 
     // Find entries with glyphs
-    const glyphEntries = comments.filter(entry => entry.glyph)
+    const glyphEntries = comments.filter((entry) => entry.glyph)
 
     expect(glyphEntries).toHaveLength(6)
-    expect(glyphEntries.map(e => e.glyph)).toContain('±') // $16
-    expect(glyphEntries.map(e => e.glyph)).toContain('⩱') // $15
-    expect(glyphEntries.map(e => e.glyph)).toContain('↑') // $36
-    expect(glyphEntries.map(e => e.glyph)).toContain('∆') // $140
-    expect(glyphEntries.map(e => e.glyph)).toContain('→') // $40
-    expect(glyphEntries.map(e => e.glyph)).toContain('=∞') // $44
+    expect(glyphEntries.map((e) => e.glyph)).toContain('±') // $16
+    expect(glyphEntries.map((e) => e.glyph)).toContain('⩱') // $15
+    expect(glyphEntries.map((e) => e.glyph)).toContain('↑') // $36
+    expect(glyphEntries.map((e) => e.glyph)).toContain('∆') // $140
+    expect(glyphEntries.map((e) => e.glyph)).toContain('→') // $40
+    expect(glyphEntries.map((e) => e.glyph)).toContain('=∞') // $44
   })
 })

--- a/etc/chess.js.api.md
+++ b/etc/chess.js.api.md
@@ -56,7 +56,9 @@ export class Chess {
         fen: string;
         comment?: string;
         suffixAnnotation?: string;
+        glyph?: string;
     }[];
+    getGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     getHeaders(): Record<string, string>;
     getSuffixAnnotation(fen?: string): Suffix | undefined;
@@ -212,6 +214,7 @@ export class Chess {
         fen: string;
         comment: string;
     }[];
+    removeGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     removeHeader(key: string): boolean;
     removeSuffixAnnotation(fen?: string): Suffix | undefined;
@@ -221,6 +224,7 @@ export class Chess {
     setCastlingRights(color: Color, rights: Partial<Record<typeof KING | typeof QUEEN, boolean>>): boolean;
     // (undocumented)
     setComment(comment: string): void;
+    setGlyph(glyph: Glyph, fen?: string): void;
     // (undocumented)
     setHeader(key: string, value: string): Record<string, string>;
     setSuffixAnnotation(suffix: Suffix, fen?: string): void;
@@ -239,6 +243,37 @@ export type Color = 'w' | 'b';
 
 // @public (undocumented)
 export const DEFAULT_POSITION = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+// @public (undocumented)
+export type Glyph = (typeof GLYPH_LIST)[number];
+
+// @public (undocumented)
+export const GLYPH_LIST: ("□" | "⨀" | "=" | "∞" | "⩲" | "⩱" | "±" | "∓" | "+−" | "-+" | "N" | "↑↑" | "↑" | "→" | "⇆" | "⊕" | "=∞" | "∆")[];
+
+// @public (undocumented)
+export const GLYPH_MAP: {
+    readonly $7: "□";
+    readonly $22: "⨀";
+    readonly $10: "=";
+    readonly $13: "∞";
+    readonly $14: "⩲";
+    readonly $15: "⩱";
+    readonly $16: "±";
+    readonly $17: "∓";
+    readonly $18: "+−";
+    readonly $19: "-+";
+    readonly $146: "N";
+    readonly $32: "↑↑";
+    readonly $36: "↑";
+    readonly $40: "→";
+    readonly $132: "⇆";
+    readonly $138: "⊕";
+    readonly $44: "=∞";
+    readonly $140: "∆";
+};
+
+// @public (undocumented)
+export type GlyphKey = keyof typeof GLYPH_MAP;
 
 // @public (undocumented)
 export const KING = "k";

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -95,6 +95,33 @@ export const SUFFIX_LIST = ['!', '?', '!!', '!?', '?!', '??'] as const
 
 export type Suffix = (typeof SUFFIX_LIST)[number]
 
+export const GLYPH_MAP = {
+  '$7': '□', // Only move
+  '$22': '⨀', // Zugzwang
+  '$10': '=', // Equal position
+  '$13': '∞', // Unclear position
+  '$14': '⩲', // White is slightly better
+  '$15': '⩱', // Black is slightly better
+  '$16': '±', // White is better
+  '$17': '∓', // Black is better
+  '$18': '+−', // White is winning
+  '$19': '-+', // Black is winning
+  '$146': 'N', // Novelty
+  '$32': '↑↑', // Development
+  '$36': '↑', // Initiative
+  '$40': '→', // Attack
+  '$132': '⇆', // Counterplay
+  '$138': '⊕', // Time trouble
+  '$44': '=∞', // With compensation
+  '$140': '∆', // With the idea
+} as const
+
+export const GLYPH_LIST = Object.values(GLYPH_MAP)
+
+export type GlyphKey = keyof typeof GLYPH_MAP
+
+export type Glyph = (typeof GLYPH_LIST)[number]
+
 export const DEFAULT_POSITION =
   'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
 
@@ -719,6 +746,7 @@ export class Chess {
   private _history: History[] = []
   private _comments: Record<string, string> = {}
   private _suffixes: Record<string, Suffix> = {}
+  private _glyphs: Record<string, Glyph> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
   private _hash = 0n
@@ -729,6 +757,7 @@ export class Chess {
   constructor(fen = DEFAULT_POSITION, { skipValidation = false } = {}) {
     this._comments = {}
     this._suffixes = {}
+    this._glyphs = {}
     this.load(fen, { skipValidation })
   }
 
@@ -1010,6 +1039,7 @@ export class Chess {
     this.load(DEFAULT_POSITION)
     this._comments = {}
     this._suffixes = {}
+    this._glyphs = {}
   }
 
   get(square: Square): Piece | undefined {
@@ -2248,6 +2278,17 @@ export class Chess {
           if (suffixAnnotation) {
             this._suffixes[this.fen()] = suffixAnnotation as Suffix
           }
+
+          // Process NAGs and convert to glyphs
+          if (node.nags && node.nags.length > 0) {
+            for (const nag of node.nags) {
+              const glyphKey = `$${nag}` as GlyphKey
+              if (glyphKey in GLYPH_MAP) {
+                this._glyphs[this.fen()] = GLYPH_MAP[glyphKey]
+                break // Use first valid glyph only
+              }
+            }
+          }
         }
       }
 
@@ -2680,27 +2721,32 @@ export class Chess {
     fen: string
     comment?: string
     suffixAnnotation?: string
+    glyph?: string
   }[] {
     this._pruneComments()
 
     const allFenKeys = new Set<string>()
     Object.keys(this._comments).forEach((fen) => allFenKeys.add(fen))
     Object.keys(this._suffixes).forEach((fen) => allFenKeys.add(fen))
+    Object.keys(this._glyphs).forEach((fen) => allFenKeys.add(fen))
 
     const result: {
       fen: string
       comment?: string
       suffixAnnotation?: string
+      glyph?: string
     }[] = []
 
     for (const fen of allFenKeys) {
       const commentContent = this._comments[fen]
       const suffixAnnotation = this._suffixes[fen]
+      const glyph = this._glyphs[fen]
 
       const entry: {
         fen: string
         comment?: string
         suffixAnnotation?: string
+        glyph?: string
       } = {
         fen: fen,
       }
@@ -2711,6 +2757,10 @@ export class Chess {
 
       if (suffixAnnotation !== undefined) {
         entry.suffixAnnotation = suffixAnnotation
+      }
+
+      if (glyph !== undefined) {
+        entry.glyph = glyph
       }
 
       result.push(entry)
@@ -2746,6 +2796,35 @@ export class Chess {
     const key = fen || this.fen()
     const old = this._suffixes[key]
     delete this._suffixes[key]
+    return old
+  }
+
+  /**
+   * Get the glyph for the given position (or current one).
+   */
+  public getGlyph(fen?: string): Glyph | undefined {
+    const key = fen ?? this.fen()
+    return this._glyphs[key]
+  }
+
+  /**
+   * Set or overwrite the glyph for the given position (or current).
+   * Throws if the glyph isn't one of the allowed GLYPH_LIST values.
+   */
+  public setGlyph(glyph: Glyph, fen?: string): void {
+    if (!GLYPH_LIST.includes(glyph)) {
+      throw new Error(`Invalid glyph: ${glyph}`)
+    }
+    this._glyphs[fen || this.fen()] = glyph
+  }
+
+  /**
+   * Remove the glyph for the given position (or current).
+   */
+  public removeGlyph(fen?: string): Glyph | undefined {
+    const key = fen || this.fen()
+    const old = this._glyphs[key]
+    delete this._glyphs[key]
     return old
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -96,24 +96,24 @@ export const SUFFIX_LIST = ['!', '?', '!!', '!?', '?!', '??'] as const
 export type Suffix = (typeof SUFFIX_LIST)[number]
 
 export const GLYPH_MAP = {
-  '$7': '□', // Only move
-  '$22': '⨀', // Zugzwang
-  '$10': '=', // Equal position
-  '$13': '∞', // Unclear position
-  '$14': '⩲', // White is slightly better
-  '$15': '⩱', // Black is slightly better
-  '$16': '±', // White is better
-  '$17': '∓', // Black is better
-  '$18': '+−', // White is winning
-  '$19': '-+', // Black is winning
-  '$146': 'N', // Novelty
-  '$32': '↑↑', // Development
-  '$36': '↑', // Initiative
-  '$40': '→', // Attack
-  '$132': '⇆', // Counterplay
-  '$138': '⊕', // Time trouble
-  '$44': '=∞', // With compensation
-  '$140': '∆', // With the idea
+  $7: '□', // Only move
+  $22: '⨀', // Zugzwang
+  $10: '=', // Equal position
+  $13: '∞', // Unclear position
+  $14: '⩲', // White is slightly better
+  $15: '⩱', // Black is slightly better
+  $16: '±', // White is better
+  $17: '∓', // Black is better
+  $18: '+−', // White is winning
+  $19: '-+', // Black is winning
+  $146: 'N', // Novelty
+  $32: '↑↑', // Development
+  $36: '↑', // Initiative
+  $40: '→', // Attack
+  $132: '⇆', // Counterplay
+  $138: '⊕', // Time trouble
+  $44: '=∞', // With compensation
+  $140: '∆', // With the idea
 } as const
 
 export const GLYPH_LIST = Object.values(GLYPH_MAP)


### PR DESCRIPTION
  ## Changes

  - **New glyph system**: Added `GLYPH_MAP` with 18 Lichess-supported glyphs (□, ⨀, =, ∞, ⩲, ⩱, ±, ∓,
  +−, -+, N, ↑↑, ↑, →, ⇆, ⊕, =∞, ∆)
  - **Public API**: Added `getGlyph()`, `setGlyph()`, `removeGlyph()` methods
  - **PGN integration**: NAGs like `$14`, `$16` are now parsed and converted to glyphs during
  `loadPgn()`
  - **Extended getComments()**: Now returns optional `glyph` field alongside comments and suffix
  annotations
  - **Full test coverage**: 9 comprehensive tests covering all functionality

  ## Example Usage

  ```typescript
  const chess = new Chess()

  // Manual glyph setting
  chess.move('e4')
  chess.setGlyph('±') // White is better
  console.log(chess.getGlyph()) // "±"

  // PGN parsing with NAGs
  chess.loadPgn('1. e4 $16 e5 $6 *')
  chess.getComments() // Returns positions with glyph: "±"
  ```