### PR TITLE
Add NAGs support

### DIFF
--- a/__tests__/comments.test.ts
+++ b/__tests__/comments.test.ts
@@ -137,10 +137,14 @@ describe('Manipulate Comments', () => {
     const e4 = chess.fen()
     chess.setComment('good move')
     expect(chess.getComment()).toEqual('good move')
-    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move', nags: [] }])
+    expect(chess.getComments()).toEqual([
+      { fen: e4, comment: 'good move', nags: [] },
+    ])
     chess.move('e5')
     expect(chess.getComment()).toBeUndefined()
-    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move', nags: [] }])
+    expect(chess.getComments()).toEqual([
+      { fen: e4, comment: 'good move', nags: [] },
+    ])
     expect(chess.pgn().endsWith('1. e4 {good move} e5 *')).toBe(true)
   })
 

--- a/__tests__/comments.test.ts
+++ b/__tests__/comments.test.ts
@@ -25,21 +25,25 @@ describe('Suffix-Only Support', () => {
       {
         fen: fen1,
         comment: 'English Opening',
+        nags: [],
       },
       {
         fen: fen2,
         comment: 'Aggressive',
         suffixAnnotation: '!?',
+        nags: [],
       },
       {
         fen: fen3,
         comment: 'Best Move',
         suffixAnnotation: '!!',
+        nags: [],
       },
       {
         fen: fen4,
         comment: 'Blunder',
         suffixAnnotation: '??',
+        nags: [],
       },
     ])
   })
@@ -68,15 +72,18 @@ describe('Chess getComments - First Approach (Suffix-Only Handling)', () => {
       {
         fen: fenC4,
         comment: 'Comment for c4',
+        nags: [],
       },
       {
         fen: fenE5,
         comment: 'Comment and Suffix for e5',
         suffixAnnotation: '!?',
+        nags: [],
       },
       {
         fen: fenNf3,
         suffixAnnotation: '!!',
+        nags: [],
       },
     ]
 
@@ -98,6 +105,7 @@ describe('Chess getComments - First Approach (Suffix-Only Handling)', () => {
     expect(entryForCurrentFen).toEqual({
       fen: currentFen,
       suffixAnnotation: '?!',
+      nags: [],
     })
   })
 })
@@ -118,7 +126,7 @@ describe('Manipulate Comments', () => {
     chess.setComment('starting position')
     expect(chess.getComment()).toEqual('starting position')
     expect(chess.getComments()).toEqual([
-      { fen: chess.fen(), comment: 'starting position' },
+      { fen: chess.fen(), comment: 'starting position', nags: [] },
     ])
     expect(chess.pgn().endsWith('{starting position} *')).toBe(true)
   })
@@ -129,10 +137,10 @@ describe('Manipulate Comments', () => {
     const e4 = chess.fen()
     chess.setComment('good move')
     expect(chess.getComment()).toEqual('good move')
-    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move' }])
+    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move', nags: [] }])
     chess.move('e5')
     expect(chess.getComment()).toBeUndefined()
-    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move' }])
+    expect(chess.getComments()).toEqual([{ fen: e4, comment: 'good move', nags: [] }])
     expect(chess.pgn().endsWith('1. e4 {good move} e5 *')).toBe(true)
   })
 
@@ -143,7 +151,7 @@ describe('Manipulate Comments', () => {
     chess.setComment('dubious move')
     expect(chess.getComment()).toEqual('dubious move')
     expect(chess.getComments()).toEqual([
-      { fen: chess.fen(), comment: 'dubious move' },
+      { fen: chess.fen(), comment: 'dubious move', nags: [] },
     ])
     expect(chess.pgn().endsWith('1. e4 e6 {dubious move} *')).toBe(true)
   })
@@ -161,7 +169,7 @@ describe('Manipulate Comments', () => {
     chess.setComment('starting position')
     expect(chess.getComment()).toEqual('starting position')
     expect(chess.getComments()).toEqual([
-      { fen: initial, comment: 'starting position' },
+      { fen: initial, comment: 'starting position', nags: [] },
     ])
     expect(chess.pgn().endsWith('{starting position} *')).toBe(true)
 
@@ -170,8 +178,8 @@ describe('Manipulate Comments', () => {
     chess.setComment('good move')
     expect(chess.getComment()).toEqual('good move')
     expect(chess.getComments()).toEqual([
-      { fen: initial, comment: 'starting position' },
-      { fen: e4, comment: 'good move' },
+      { fen: initial, comment: 'starting position', nags: [] },
+      { fen: e4, comment: 'good move', nags: [] },
     ])
     expect(
       chess.pgn().endsWith('{starting position} 1. e4 {good move} *'),
@@ -182,9 +190,9 @@ describe('Manipulate Comments', () => {
     chess.setComment('dubious move')
     expect(chess.getComment()).toEqual('dubious move')
     expect(chess.getComments()).toEqual([
-      { fen: initial, comment: 'starting position' },
-      { fen: e4, comment: 'good move' },
-      { fen: e6, comment: 'dubious move' },
+      { fen: initial, comment: 'starting position', nags: [] },
+      { fen: e4, comment: 'good move', nags: [] },
+      { fen: e6, comment: 'dubious move', nags: [] },
     ])
     expect(
       chess
@@ -206,9 +214,9 @@ describe('Manipulate Comments', () => {
     const e6 = chess.fen()
     chess.setComment('dubious move')
     expect(chess.getComments()).toEqual([
-      { fen: initial, comment: 'starting position' },
-      { fen: e4, comment: 'good move' },
-      { fen: e6, comment: 'dubious move' },
+      { fen: initial, comment: 'starting position', nags: [] },
+      { fen: e4, comment: 'good move', nags: [] },
+      { fen: e6, comment: 'dubious move', nags: [] },
     ])
     expect(chess.removeComment()).toEqual('dubious move')
     expect(
@@ -230,7 +238,7 @@ describe('Manipulate Comments', () => {
     chess.move('d4')
     chess.setComment('positional')
     expect(chess.getComments()).toEqual([
-      { fen: chess.fen(), comment: 'positional' },
+      { fen: chess.fen(), comment: 'positional', nags: [] },
     ])
     expect(chess.pgn().endsWith('1. d4 {positional} *')).toBe(true)
   })
@@ -241,7 +249,7 @@ describe('Manipulate Comments', () => {
       chess.move('e4')
       chess.setComment('good move')
       expect(chess.getComments()).toEqual([
-        { fen: chess.fen(), comment: 'good move' },
+        { fen: chess.fen(), comment: 'good move', nags: [] },
       ])
       fn(chess)
       expect(chess.getComments()).toEqual([])

--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -1,0 +1,201 @@
+import { Chess, Glyph } from '../src/chess'
+import { describe, expect, it } from 'vitest'
+
+describe('Glyph Support', () => {
+  it('captures multiple NAGs and converts to glyphs', () => {
+    const chess = new Chess()
+    const pgn =
+      '1. e4 $1 {Great move} ' +
+      'e5 $6 {Questionable} ' +
+      '2. Nf3 $14 Nc6 $10 *'
+
+    chess.loadPgn(pgn)
+
+    const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    const fen2 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    const fen3 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
+    const fen4 = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
+
+    expect(chess.fen()).toEqual(fen4)
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: fen1,
+      comment: 'Great move',
+    })
+    expect(comments).toContainEqual({
+      fen: fen2,
+      comment: 'Questionable',
+    })
+    expect(comments).toContainEqual({
+      fen: fen3,
+      glyph: '⩲', // $14 -> White is slightly better
+    })
+    expect(comments).toContainEqual({
+      fen: fen4,
+      glyph: '=', // $10 -> Equal position
+    })
+  })
+
+  it('handles multiple NAGs by using first valid glyph', () => {
+    const chess = new Chess()
+    const pgn = '1. e4 $1 $14 $99 $10 *' // Mix of invalid and valid NAGs
+
+    chess.loadPgn(pgn)
+
+    const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
+    const comments = chess.getComments()
+
+    expect(comments).toContainEqual({
+      fen: fen1,
+      glyph: '⩲', // Should use $14 (first valid glyph) not $10
+    })
+  })
+
+  it('manually set glyph with validation', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const currentFen = chess.fen()
+
+    // Valid glyph
+    chess.setGlyph('±')
+    expect(chess.getGlyph()).toEqual('±')
+    expect(chess.getGlyph(currentFen)).toEqual('±')
+
+    // Invalid glyph should throw
+    expect(() => chess.setGlyph('invalid' as never)).toThrow('Invalid glyph: invalid')
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: currentFen,
+      glyph: '±',
+    })
+  })
+
+  it('remove glyph functionality', () => {
+    const chess = new Chess()
+    chess.move('e4')
+
+    // Set a glyph
+    chess.setGlyph('∞')
+    expect(chess.getGlyph()).toEqual('∞')
+
+    // Remove it
+    const removed = chess.removeGlyph()
+    expect(removed).toEqual('∞')
+    expect(chess.getGlyph()).toBeUndefined()
+
+    // Remove non-existent should return undefined
+    const removedAgain = chess.removeGlyph()
+    expect(removedAgain).toBeUndefined()
+
+    // Comments should be empty after removal
+    expect(chess.getComments()).toEqual([])
+  })
+
+  it('glyph with specific FEN', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const fen1 = chess.fen()
+    chess.move('e5')
+    const fen2 = chess.fen()
+
+    // Set glyph for previous position
+    chess.setGlyph('→', fen1)
+    expect(chess.getGlyph(fen1)).toEqual('→')
+    expect(chess.getGlyph(fen2)).toBeUndefined()
+    expect(chess.getGlyph()).toBeUndefined() // Current position has no glyph
+
+    // Remove glyph by FEN
+    const removed = chess.removeGlyph(fen1)
+    expect(removed).toEqual('→')
+    expect(chess.getGlyph(fen1)).toBeUndefined()
+  })
+
+  it('integration with comments and suffixes', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    const currentFen = chess.fen()
+
+    // Set all three types of annotations
+    chess.setComment('Excellent opening')
+    chess.setSuffixAnnotation('!!')
+    chess.setGlyph('⩲')
+
+    const comments = chess.getComments()
+    expect(comments).toContainEqual({
+      fen: currentFen,
+      comment: 'Excellent opening',
+      suffixAnnotation: '!!',
+      glyph: '⩲',
+    })
+  })
+
+  it('reset clears all glyphs', () => {
+    const chess = new Chess()
+    chess.move('e4')
+    chess.setGlyph('±')
+    chess.move('e5')
+    chess.setGlyph('∓')
+
+    expect(chess.getComments()).toHaveLength(2)
+
+    chess.reset()
+    expect(chess.getComments()).toEqual([])
+    expect(chess.getGlyph()).toBeUndefined()
+  })
+
+  it('all supported lichess glyphs', () => {
+    const chess = new Chess()
+    const supportedGlyphs: Glyph[] = [
+      '□', // Only move
+      '⨀', // Zugzwang
+      '=', // Equal position
+      '∞', // Unclear position
+      '⩲', // White is slightly better
+      '⩱', // Black is slightly better
+      '±', // White is better
+      '∓', // Black is better
+      '+−', // White is winning
+      '-+', // Black is winning
+      'N', // Novelty
+      '↑↑', // Development
+      '↑', // Initiative
+      '→', // Attack
+      '⇆', // Counterplay
+      '⊕', // Time trouble
+      '=∞', // With compensation
+      '∆', // With the idea
+    ]
+
+    // Test each glyph can be set and retrieved
+    supportedGlyphs.forEach(glyph => {
+      chess.setGlyph(glyph)
+      expect(chess.getGlyph()).toEqual(glyph)
+    })
+  })
+
+  it('PGN with NAGs mapped to glyphs', () => {
+    const chess = new Chess()
+    const pgn = `
+      1. e4 $16 $132 e5 $15
+      2. Nf3 $36 Nc6 $140
+      3. Bc4 $40 Be7 $44 *
+    `
+
+    chess.loadPgn(pgn)
+
+    const comments = chess.getComments()
+
+    // Find entries with glyphs
+    const glyphEntries = comments.filter(entry => entry.glyph)
+
+    expect(glyphEntries).toHaveLength(6)
+    expect(glyphEntries.map(e => e.glyph)).toContain('±') // $16
+    expect(glyphEntries.map(e => e.glyph)).toContain('⩱') // $15
+    expect(glyphEntries.map(e => e.glyph)).toContain('↑') // $36
+    expect(glyphEntries.map(e => e.glyph)).toContain('∆') // $140
+    expect(glyphEntries.map(e => e.glyph)).toContain('→') // $40
+    expect(glyphEntries.map(e => e.glyph)).toContain('=∞') // $44
+  })
+})

--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -94,11 +94,11 @@ describe('NAG Support', () => {
     // Remove all NAGs
     const removedAll = chess.removeNags()
     expect(removedAll).toEqual([36])
-    expect(chess.getNags()).toBeUndefined()
+    expect(chess.getNags()).toEqual([])
 
-    // Remove non-existent should return undefined
+    // Remove non-existent should return empty array
     const removedAgain = chess.removeNags()
-    expect(removedAgain).toBeUndefined()
+    expect(removedAgain).toEqual([])
 
     // Comments should be empty after removal
     expect(chess.getComments()).toEqual([])
@@ -114,13 +114,13 @@ describe('NAG Support', () => {
     // Set NAG for previous position
     chess.addNag(40, fen1) // → - Attack
     expect(chess.getNags(fen1)).toEqual([40])
-    expect(chess.getNags(fen2)).toBeUndefined()
-    expect(chess.getNags()).toBeUndefined() // Current position has no NAG
+    expect(chess.getNags(fen2)).toEqual([])
+    expect(chess.getNags()).toEqual([]) // Current position has no NAG
 
     // Remove NAG by FEN
     const removed = chess.removeNags(fen1)
     expect(removed).toEqual([40])
-    expect(chess.getNags(fen1)).toBeUndefined()
+    expect(chess.getNags(fen1)).toEqual([])
   })
 
   it('integration with comments and suffixes', () => {
@@ -153,7 +153,7 @@ describe('NAG Support', () => {
 
     chess.reset()
     expect(chess.getComments()).toEqual([])
-    expect(chess.getNags()).toBeUndefined()
+    expect(chess.getNags()).toEqual([])
   })
 
   it('nagToGlyph utility function', () => {

--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -13,8 +13,10 @@ describe('Glyph Support', () => {
 
     const fen1 = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1'
     const fen2 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
-    const fen3 = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
-    const fen4 = 'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
+    const fen3 =
+      'rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
+    const fen4 =
+      'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3'
 
     expect(chess.fen()).toEqual(fen4)
 
@@ -63,7 +65,9 @@ describe('Glyph Support', () => {
     expect(chess.getGlyph(currentFen)).toEqual('±')
 
     // Invalid glyph should throw
-    expect(() => chess.setGlyph('invalid' as never)).toThrow('Invalid glyph: invalid')
+    expect(() => chess.setGlyph('invalid' as never)).toThrow(
+      'Invalid glyph: invalid',
+    )
 
     const comments = chess.getComments()
     expect(comments).toContainEqual({
@@ -169,7 +173,7 @@ describe('Glyph Support', () => {
     ]
 
     // Test each glyph can be set and retrieved
-    supportedGlyphs.forEach(glyph => {
+    supportedGlyphs.forEach((glyph) => {
       chess.setGlyph(glyph)
       expect(chess.getGlyph()).toEqual(glyph)
     })
@@ -188,14 +192,14 @@ describe('Glyph Support', () => {
     const comments = chess.getComments()
 
     // Find entries with glyphs
-    const glyphEntries = comments.filter(entry => entry.glyph)
+    const glyphEntries = comments.filter((entry) => entry.glyph)
 
     expect(glyphEntries).toHaveLength(6)
-    expect(glyphEntries.map(e => e.glyph)).toContain('±') // $16
-    expect(glyphEntries.map(e => e.glyph)).toContain('⩱') // $15
-    expect(glyphEntries.map(e => e.glyph)).toContain('↑') // $36
-    expect(glyphEntries.map(e => e.glyph)).toContain('∆') // $140
-    expect(glyphEntries.map(e => e.glyph)).toContain('→') // $40
-    expect(glyphEntries.map(e => e.glyph)).toContain('=∞') // $44
+    expect(glyphEntries.map((e) => e.glyph)).toContain('±') // $16
+    expect(glyphEntries.map((e) => e.glyph)).toContain('⩱') // $15
+    expect(glyphEntries.map((e) => e.glyph)).toContain('↑') // $36
+    expect(glyphEntries.map((e) => e.glyph)).toContain('∆') // $140
+    expect(glyphEntries.map((e) => e.glyph)).toContain('→') // $40
+    expect(glyphEntries.map((e) => e.glyph)).toContain('=∞') // $44
   })
 })

--- a/__tests__/glyphs.test.ts
+++ b/__tests__/glyphs.test.ts
@@ -1,8 +1,8 @@
-import { Chess, Glyph } from '../src/chess'
+import { Chess, nagToGlyph } from '../src/chess'
 import { describe, expect, it } from 'vitest'
 
-describe('Glyph Support', () => {
-  it('captures multiple NAGs and converts to glyphs', () => {
+describe('NAG Support', () => {
+  it('captures multiple NAGs from PGN', () => {
     const chess = new Chess()
     const pgn =
       '1. e4 $1 {Great move} ' +
@@ -24,24 +24,26 @@ describe('Glyph Support', () => {
     expect(comments).toContainEqual({
       fen: fen1,
       comment: 'Great move',
+      nags: [1],
     })
     expect(comments).toContainEqual({
       fen: fen2,
       comment: 'Questionable',
+      nags: [6],
     })
     expect(comments).toContainEqual({
       fen: fen3,
-      glyph: '⩲', // $14 -> White is slightly better
+      nags: [14],
     })
     expect(comments).toContainEqual({
       fen: fen4,
-      glyph: '=', // $10 -> Equal position
+      nags: [10],
     })
   })
 
-  it('handles multiple NAGs by using first valid glyph', () => {
+  it('handles multiple NAGs per position', () => {
     const chess = new Chess()
-    const pgn = '1. e4 $1 $14 $99 $10 *' // Mix of invalid and valid NAGs
+    const pgn = '1. e4 $1 $14 $99 $10 *' // Mix of NAGs
 
     chess.loadPgn(pgn)
 
@@ -50,70 +52,75 @@ describe('Glyph Support', () => {
 
     expect(comments).toContainEqual({
       fen: fen1,
-      glyph: '⩲', // Should use $14 (first valid glyph) not $10
+      nags: [1, 14, 99, 10], // All NAGs stored
     })
   })
 
-  it('manually set glyph with validation', () => {
+  it('manually add NAG', () => {
     const chess = new Chess()
     chess.move('e4')
     const currentFen = chess.fen()
 
-    // Valid glyph
-    chess.setGlyph('±')
-    expect(chess.getGlyph()).toEqual('±')
-    expect(chess.getGlyph(currentFen)).toEqual('±')
+    // Add NAG 16 (± - White is better)
+    chess.addNag(16)
+    expect(chess.getNags()).toEqual([16])
+    expect(chess.getNags(currentFen)).toEqual([16])
 
-    // Invalid glyph should throw
-    expect(() => chess.setGlyph('invalid' as never)).toThrow(
-      'Invalid glyph: invalid',
-    )
+    // Add another NAG
+    chess.addNag(36) // ↑ - Initiative
+    expect(chess.getNags()).toEqual([16, 36])
 
     const comments = chess.getComments()
     expect(comments).toContainEqual({
       fen: currentFen,
-      glyph: '±',
+      nags: [16, 36],
     })
   })
 
-  it('remove glyph functionality', () => {
+  it('remove NAG functionality', () => {
     const chess = new Chess()
     chess.move('e4')
 
-    // Set a glyph
-    chess.setGlyph('∞')
-    expect(chess.getGlyph()).toEqual('∞')
+    // Add NAGs
+    chess.addNag(13) // ∞ - Unclear position
+    chess.addNag(36) // ↑ - Initiative
+    expect(chess.getNags()).toEqual([13, 36])
 
-    // Remove it
-    const removed = chess.removeGlyph()
-    expect(removed).toEqual('∞')
-    expect(chess.getGlyph()).toBeUndefined()
+    // Remove one NAG
+    const removed = chess.removeNag(13)
+    expect(removed).toBe(true)
+    expect(chess.getNags()).toEqual([36])
+
+    // Remove all NAGs
+    const removedAll = chess.removeNags()
+    expect(removedAll).toEqual([36])
+    expect(chess.getNags()).toBeUndefined()
 
     // Remove non-existent should return undefined
-    const removedAgain = chess.removeGlyph()
+    const removedAgain = chess.removeNags()
     expect(removedAgain).toBeUndefined()
 
     // Comments should be empty after removal
     expect(chess.getComments()).toEqual([])
   })
 
-  it('glyph with specific FEN', () => {
+  it('NAG with specific FEN', () => {
     const chess = new Chess()
     chess.move('e4')
     const fen1 = chess.fen()
     chess.move('e5')
     const fen2 = chess.fen()
 
-    // Set glyph for previous position
-    chess.setGlyph('→', fen1)
-    expect(chess.getGlyph(fen1)).toEqual('→')
-    expect(chess.getGlyph(fen2)).toBeUndefined()
-    expect(chess.getGlyph()).toBeUndefined() // Current position has no glyph
+    // Set NAG for previous position
+    chess.addNag(40, fen1) // → - Attack
+    expect(chess.getNags(fen1)).toEqual([40])
+    expect(chess.getNags(fen2)).toBeUndefined()
+    expect(chess.getNags()).toBeUndefined() // Current position has no NAG
 
-    // Remove glyph by FEN
-    const removed = chess.removeGlyph(fen1)
-    expect(removed).toEqual('→')
-    expect(chess.getGlyph(fen1)).toBeUndefined()
+    // Remove NAG by FEN
+    const removed = chess.removeNags(fen1)
+    expect(removed).toEqual([40])
+    expect(chess.getNags(fen1)).toBeUndefined()
   })
 
   it('integration with comments and suffixes', () => {
@@ -124,62 +131,59 @@ describe('Glyph Support', () => {
     // Set all three types of annotations
     chess.setComment('Excellent opening')
     chess.setSuffixAnnotation('!!')
-    chess.setGlyph('⩲')
+    chess.addNag(14) // ⩲ - White is slightly better
 
     const comments = chess.getComments()
     expect(comments).toContainEqual({
       fen: currentFen,
       comment: 'Excellent opening',
       suffixAnnotation: '!!',
-      glyph: '⩲',
+      nags: [14],
     })
   })
 
-  it('reset clears all glyphs', () => {
+  it('reset clears all NAGs', () => {
     const chess = new Chess()
     chess.move('e4')
-    chess.setGlyph('±')
+    chess.addNag(16) // ± - White is better
     chess.move('e5')
-    chess.setGlyph('∓')
+    chess.addNag(17) // ∓ - Black is better
 
     expect(chess.getComments()).toHaveLength(2)
 
     chess.reset()
     expect(chess.getComments()).toEqual([])
-    expect(chess.getGlyph()).toBeUndefined()
+    expect(chess.getNags()).toBeUndefined()
   })
 
-  it('all supported lichess glyphs', () => {
-    const chess = new Chess()
-    const supportedGlyphs: Glyph[] = [
-      '□', // Only move
-      '⨀', // Zugzwang
-      '=', // Equal position
-      '∞', // Unclear position
-      '⩲', // White is slightly better
-      '⩱', // Black is slightly better
-      '±', // White is better
-      '∓', // Black is better
-      '+−', // White is winning
-      '-+', // Black is winning
-      'N', // Novelty
-      '↑↑', // Development
-      '↑', // Initiative
-      '→', // Attack
-      '⇆', // Counterplay
-      '⊕', // Time trouble
-      '=∞', // With compensation
-      '∆', // With the idea
-    ]
+  it('nagToGlyph utility function', () => {
+    // Test mapping for all supported NAGs
+    expect(nagToGlyph(7)).toBe('□') // Only move
+    expect(nagToGlyph(22)).toBe('⨀') // Zugzwang
+    expect(nagToGlyph(10)).toBe('=') // Equal position
+    expect(nagToGlyph(13)).toBe('∞') // Unclear position
+    expect(nagToGlyph(14)).toBe('⩲') // White is slightly better
+    expect(nagToGlyph(15)).toBe('⩱') // Black is slightly better
+    expect(nagToGlyph(16)).toBe('±') // White is better
+    expect(nagToGlyph(17)).toBe('∓') // Black is better
+    expect(nagToGlyph(18)).toBe('+−') // White is winning
+    expect(nagToGlyph(19)).toBe('-+') // Black is winning
+    expect(nagToGlyph(146)).toBe('N') // Novelty
+    expect(nagToGlyph(32)).toBe('↑↑') // Development
+    expect(nagToGlyph(36)).toBe('↑') // Initiative
+    expect(nagToGlyph(40)).toBe('→') // Attack
+    expect(nagToGlyph(132)).toBe('⇆') // Counterplay
+    expect(nagToGlyph(138)).toBe('⊕') // Time trouble
+    expect(nagToGlyph(44)).toBe('=∞') // With compensation
+    expect(nagToGlyph(140)).toBe('∆') // With the idea
 
-    // Test each glyph can be set and retrieved
-    supportedGlyphs.forEach((glyph) => {
-      chess.setGlyph(glyph)
-      expect(chess.getGlyph()).toEqual(glyph)
-    })
+    // Test unmapped NAG returns undefined
+    expect(nagToGlyph(1)).toBeUndefined()
+    expect(nagToGlyph(99)).toBeUndefined()
+    expect(nagToGlyph(999)).toBeUndefined()
   })
 
-  it('PGN with NAGs mapped to glyphs', () => {
+  it('PGN with multiple NAGs per position', () => {
     const chess = new Chess()
     const pgn = `
       1. e4 $16 $132 e5 $15
@@ -191,15 +195,53 @@ describe('Glyph Support', () => {
 
     const comments = chess.getComments()
 
-    // Find entries with glyphs
-    const glyphEntries = comments.filter((entry) => entry.glyph)
+    // Find entries with NAGs
+    const nagEntries = comments.filter((entry) => entry.nags)
 
-    expect(glyphEntries).toHaveLength(6)
-    expect(glyphEntries.map((e) => e.glyph)).toContain('±') // $16
-    expect(glyphEntries.map((e) => e.glyph)).toContain('⩱') // $15
-    expect(glyphEntries.map((e) => e.glyph)).toContain('↑') // $36
-    expect(glyphEntries.map((e) => e.glyph)).toContain('∆') // $140
-    expect(glyphEntries.map((e) => e.glyph)).toContain('→') // $40
-    expect(glyphEntries.map((e) => e.glyph)).toContain('=∞') // $44
+    expect(nagEntries).toHaveLength(6)
+
+    // Check specific positions have correct NAGs
+    const e4Entry = comments.find((c) =>
+      c.fen.includes('rnbqkbnr/pppppppp/8/8/4P3'),
+    )
+    expect(e4Entry?.nags).toEqual([16, 132])
+
+    const e5Entry = comments.find((c) =>
+      c.fen.includes('rnbqkbnr/pppp1ppp/8/4p3/4P3/8'),
+    )
+    expect(e5Entry?.nags).toEqual([15])
+
+    // Verify all NAGs can be converted to glyphs
+    expect(nagToGlyph(16)).toBe('±')
+    expect(nagToGlyph(132)).toBe('⇆')
+    expect(nagToGlyph(15)).toBe('⩱')
+    expect(nagToGlyph(36)).toBe('↑')
+    expect(nagToGlyph(140)).toBe('∆')
+    expect(nagToGlyph(40)).toBe('→')
+    expect(nagToGlyph(44)).toBe('=∞')
+  })
+
+  it('setNags replaces existing NAGs', () => {
+    const chess = new Chess()
+    chess.move('e4')
+
+    chess.addNag(10)
+    chess.addNag(14)
+    expect(chess.getNags()).toEqual([10, 14])
+
+    // Replace with new set
+    chess.setNags([16, 36, 40])
+    expect(chess.getNags()).toEqual([16, 36, 40])
+  })
+
+  it('addNag avoids duplicates', () => {
+    const chess = new Chess()
+    chess.move('e4')
+
+    chess.addNag(10)
+    chess.addNag(10)
+    chess.addNag(10)
+
+    expect(chess.getNags()).toEqual([10])
   })
 })

--- a/__tests__/load-pgn.test.ts
+++ b/__tests__/load-pgn.test.ts
@@ -91,6 +91,7 @@ test('loadPgn - works - comments', () => {
     {
       fen: 'rn1qkbnr/ppp2ppp/3p4/4p3/3PP1b1/5N2/PPP2PPP/RNBQKB1R w KQkq - 1 4',
       comment: 'This is a weak move already.--Fischer',
+      nags: [],
     },
     {
       fen: 'rn2kb1r/pp2qppp/2p2n2/4p1B1/2B1P3/1QN5/PPP2PPP/R3K2R b KQkq - 1 9',
@@ -98,6 +99,7 @@ test('loadPgn - works - comments', () => {
         "Black is in what's like a zugzwang position, here. He can't " +
         "develop the [Queen's] knight because the pawn, is hanging, the " +
         'bishop is blocked because of the Queen.--Fischer',
+      nags: [],
     },
   ]
   const pgn = `
@@ -141,12 +143,14 @@ test('loadPgn - works - comments (before first move)', () => {
         'and my previous record against Kevin was 4 losses and 1 draw ' +
         'out of 5 games.  All of our previous games were between ' +
         '1992-1998. ',
+      nags: [],
     },
     {
       fen: 'rnbqkb1r/pppp1ppp/4pn2/8/2PP4/6P1/PP2PP1P/RNBQKBNR b KQkq - 0 3',
       comment:
         ' Avrukh says to play 3.g3 instead of 3.Nf3 in case the Knight ' +
         'later comes to e2, as in the Bogo-Indian. ',
+      nags: [],
     },
   ]
   const pgn = `
@@ -243,11 +247,13 @@ test('loadPgn - works - preserves RAV inside comments', () => {
     {
       fen: 'rnbqkbnr/pp1p1ppp/4p3/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3',
       comment: ' Sicilian Defence, French Variation ',
+      nags: [],
     },
     {
       fen: '3q1rk1/1b1rbp1p/p2ppnp1/1p6/3BPP2/P1NB3Q/1PP3PP/4RR1K w - - 0 18',
       comment: ' (0.05 → 1.03) Inaccuracy. The best move was h6. ',
       suffixAnnotation: '?',
+      nags: [],
     },
   ]
   const pgn = `
@@ -274,6 +280,7 @@ test('loadPgn - works - mixed RAV and comments', () => {
     {
       fen: 'rnbqk2r/ppp1ppbp/5np1/3p4/3P1B2/4PN1P/PPP2PP1/RN1QKB1R b KQkq - 0 5',
       comment: ' 5. Be2 O-O 6. O-O c5 7. c3 Nc6 ',
+      nags: [],
     },
   ]
   const pgn = `
@@ -391,6 +398,7 @@ test('loadPgn - works - parses different newline characters', () => {
     {
       fen: 'rn1qkbnr/ppp2ppp/3p4/4p3/3PP1b1/5N2/PPP2PPP/RNBQKB1R w KQkq - 1 4',
       comment: 'This is a weak move already.--Fischer',
+      nags: [],
     },
     {
       fen: 'rn2kb1r/pp2qppp/2p2n2/4p1B1/2B1P3/1QN5/PPP2PPP/R3K2R b KQkq - 1 9',
@@ -398,6 +406,7 @@ test('loadPgn - works - parses different newline characters', () => {
         "Black is in what's like a zugzwang position, here. He can't " +
         "develop the [Queen's] knight because the pawn, is hanging, the " +
         'bishop is blocked because of the Queen.--Fischer',
+      nags: [],
     },
   ]
   const pgn = [

--- a/etc/chess.js.api.md
+++ b/etc/chess.js.api.md
@@ -57,11 +57,11 @@ export class Chess {
         fen: string;
         comment?: string;
         suffixAnnotation?: string;
-        nags?: NAG[];
+        nags: NAG[];
     }[];
     // (undocumented)
     getHeaders(): Record<string, string>;
-    getNags(fen?: string): NAG[] | undefined;
+    getNags(fen?: string): NAG[];
     getSuffixAnnotation(fen?: string): Suffix | undefined;
     // (undocumented)
     hash(): string;
@@ -218,7 +218,7 @@ export class Chess {
     // (undocumented)
     removeHeader(key: string): boolean;
     removeNag(nag: NAG, fen?: string): boolean;
-    removeNags(fen?: string): NAG[] | undefined;
+    removeNags(fen?: string): NAG[];
     removeSuffixAnnotation(fen?: string): Suffix | undefined;
     // (undocumented)
     reset(): void;

--- a/etc/chess.js.api.md
+++ b/etc/chess.js.api.md
@@ -15,6 +15,7 @@ export class Chess {
     constructor(fen?: string, { skipValidation }?: {
         skipValidation?: boolean | undefined;
     });
+    addNag(nag: NAG, fen?: string): void;
     // (undocumented)
     ascii(): string;
     // (undocumented)
@@ -56,11 +57,11 @@ export class Chess {
         fen: string;
         comment?: string;
         suffixAnnotation?: string;
-        glyph?: string;
+        nags?: NAG[];
     }[];
-    getGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     getHeaders(): Record<string, string>;
+    getNags(fen?: string): NAG[] | undefined;
     getSuffixAnnotation(fen?: string): Suffix | undefined;
     // (undocumented)
     hash(): string;
@@ -214,9 +215,10 @@ export class Chess {
         fen: string;
         comment: string;
     }[];
-    removeGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     removeHeader(key: string): boolean;
+    removeNag(nag: NAG, fen?: string): boolean;
+    removeNags(fen?: string): NAG[] | undefined;
     removeSuffixAnnotation(fen?: string): Suffix | undefined;
     // (undocumented)
     reset(): void;
@@ -224,9 +226,9 @@ export class Chess {
     setCastlingRights(color: Color, rights: Partial<Record<typeof KING | typeof QUEEN, boolean>>): boolean;
     // (undocumented)
     setComment(comment: string): void;
-    setGlyph(glyph: Glyph, fen?: string): void;
     // (undocumented)
     setHeader(key: string, value: string): Record<string, string>;
+    setNags(nags: NAG[], fen?: string): void;
     setSuffixAnnotation(suffix: Suffix, fen?: string): void;
     // (undocumented)
     setTurn(color: Color): boolean;
@@ -243,37 +245,6 @@ export type Color = 'w' | 'b';
 
 // @public (undocumented)
 export const DEFAULT_POSITION = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-
-// @public (undocumented)
-export type Glyph = (typeof GLYPH_LIST)[number];
-
-// @public (undocumented)
-export const GLYPH_LIST: ("□" | "⨀" | "=" | "∞" | "⩲" | "⩱" | "±" | "∓" | "+−" | "-+" | "N" | "↑↑" | "↑" | "→" | "⇆" | "⊕" | "=∞" | "∆")[];
-
-// @public (undocumented)
-export const GLYPH_MAP: {
-    readonly $7: "□";
-    readonly $22: "⨀";
-    readonly $10: "=";
-    readonly $13: "∞";
-    readonly $14: "⩲";
-    readonly $15: "⩱";
-    readonly $16: "±";
-    readonly $17: "∓";
-    readonly $18: "+−";
-    readonly $19: "-+";
-    readonly $146: "N";
-    readonly $32: "↑↑";
-    readonly $36: "↑";
-    readonly $40: "→";
-    readonly $132: "⇆";
-    readonly $138: "⊕";
-    readonly $44: "=∞";
-    readonly $140: "∆";
-};
-
-// @public (undocumented)
-export type GlyphKey = keyof typeof GLYPH_MAP;
 
 // @public (undocumented)
 export const KING = "k";
@@ -322,6 +293,34 @@ export class Move {
     // (undocumented)
     to: Square;
 }
+
+// @public (undocumented)
+export type NAG = number;
+
+// @public (undocumented)
+export const NAG_TO_SYMBOL: {
+    readonly 7: "□";
+    readonly 22: "⨀";
+    readonly 10: "=";
+    readonly 13: "∞";
+    readonly 14: "⩲";
+    readonly 15: "⩱";
+    readonly 16: "±";
+    readonly 17: "∓";
+    readonly 18: "+−";
+    readonly 19: "-+";
+    readonly 146: "N";
+    readonly 32: "↑↑";
+    readonly 36: "↑";
+    readonly 40: "→";
+    readonly 132: "⇆";
+    readonly 138: "⊕";
+    readonly 44: "=∞";
+    readonly 140: "∆";
+};
+
+// @public
+export function nagToGlyph(nag: NAG): string | undefined;
 
 // @public (undocumented)
 export const PAWN = "p";

--- a/etc/chess.js.api.md
+++ b/etc/chess.js.api.md
@@ -56,7 +56,9 @@ export class Chess {
         fen: string;
         comment?: string;
         suffixAnnotation?: string;
+        glyph?: string;
     }[];
+    getGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     getHeaders(): Record<string, string>;
     getSuffixAnnotation(fen?: string): Suffix | undefined;
@@ -212,6 +214,7 @@ export class Chess {
         fen: string;
         comment: string;
     }[];
+    removeGlyph(fen?: string): Glyph | undefined;
     // (undocumented)
     removeHeader(key: string): boolean;
     removeSuffixAnnotation(fen?: string): Suffix | undefined;
@@ -221,6 +224,7 @@ export class Chess {
     setCastlingRights(color: Color, rights: Partial<Record<typeof KING | typeof QUEEN, boolean>>): boolean;
     // (undocumented)
     setComment(comment: string): void;
+    setGlyph(glyph: Glyph, fen?: string): void;
     // (undocumented)
     setHeader(key: string, value: string): Record<string, string>;
     setSuffixAnnotation(suffix: Suffix, fen?: string): void;
@@ -239,6 +243,37 @@ export type Color = 'w' | 'b';
 
 // @public (undocumented)
 export const DEFAULT_POSITION = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+// @public (undocumented)
+export type Glyph = (typeof GLYPH_LIST)[number];
+
+// @public (undocumented)
+export const GLYPH_LIST: ("□" | "⨀" | "=" | "∞" | "⩲" | "⩱" | "±" | "∓" | "+−" | "-+" | "N" | "↑↑" | "↑" | "→" | "⇆" | "⊕" | "=∞" | "∆")[];
+
+// @public (undocumented)
+export const GLYPH_MAP: {
+    readonly $7: "□";
+    readonly $22: "⨀";
+    readonly $10: "=";
+    readonly $13: "∞";
+    readonly $14: "⩲";
+    readonly $15: "⩱";
+    readonly $16: "±";
+    readonly $17: "∓";
+    readonly $18: "+−";
+    readonly $19: "-+";
+    readonly $146: "N";
+    readonly $32: "↑↑";
+    readonly $36: "↑";
+    readonly $40: "→";
+    readonly $132: "⇆";
+    readonly $138: "⊕";
+    readonly $44: "=∞";
+    readonly $140: "∆";
+};
+
+// @public (undocumented)
+export type GlyphKey = keyof typeof GLYPH_MAP;
 
 // @public (undocumented)
 export const KING = "k";

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -95,6 +95,33 @@ export const SUFFIX_LIST = ['!', '?', '!!', '!?', '?!', '??'] as const
 
 export type Suffix = (typeof SUFFIX_LIST)[number]
 
+export const GLYPH_MAP = {
+  '$7': '□', // Only move
+  '$22': '⨀', // Zugzwang
+  '$10': '=', // Equal position
+  '$13': '∞', // Unclear position
+  '$14': '⩲', // White is slightly better
+  '$15': '⩱', // Black is slightly better
+  '$16': '±', // White is better
+  '$17': '∓', // Black is better
+  '$18': '+−', // White is winning
+  '$19': '-+', // Black is winning
+  '$146': 'N', // Novelty
+  '$32': '↑↑', // Development
+  '$36': '↑', // Initiative
+  '$40': '→', // Attack
+  '$132': '⇆', // Counterplay
+  '$138': '⊕', // Time trouble
+  '$44': '=∞', // With compensation
+  '$140': '∆', // With the idea
+} as const
+
+export const GLYPH_LIST = Object.values(GLYPH_MAP)
+
+export type GlyphKey = keyof typeof GLYPH_MAP
+
+export type Glyph = (typeof GLYPH_LIST)[number]
+
 export const DEFAULT_POSITION =
   'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
 
@@ -719,6 +746,7 @@ export class Chess {
   private _history: History[] = []
   private _comments: Record<string, string> = {}
   private _suffixes: Record<string, Suffix> = {}
+  private _glyphs: Record<string, Glyph> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
   private _hash = 0n
@@ -729,6 +757,7 @@ export class Chess {
   constructor(fen = DEFAULT_POSITION, { skipValidation = false } = {}) {
     this._comments = {}
     this._suffixes = {}
+    this._glyphs = {}
     this.load(fen, { skipValidation })
   }
 
@@ -1010,6 +1039,7 @@ export class Chess {
     this.load(DEFAULT_POSITION)
     this._comments = {}
     this._suffixes = {}
+    this._glyphs = {}
   }
 
   get(square: Square): Piece | undefined {
@@ -2248,6 +2278,17 @@ export class Chess {
           if (suffixAnnotation) {
             this._suffixes[this.fen()] = suffixAnnotation as Suffix
           }
+
+          // Process NAGs and convert to glyphs
+          if (node.nags && node.nags.length > 0) {
+            for (const nag of node.nags) {
+              const glyphKey = `$${nag}` as GlyphKey
+              if (glyphKey in GLYPH_MAP) {
+                this._glyphs[this.fen()] = GLYPH_MAP[glyphKey]
+                break // Use first valid glyph only
+              }
+            }
+          }
         }
       }
 
@@ -2680,27 +2721,32 @@ export class Chess {
     fen: string
     comment?: string
     suffixAnnotation?: string
+    glyph?: string
   }[] {
     this._pruneComments()
 
     const allFenKeys = new Set<string>()
     Object.keys(this._comments).forEach((fen) => allFenKeys.add(fen))
     Object.keys(this._suffixes).forEach((fen) => allFenKeys.add(fen))
+    Object.keys(this._glyphs).forEach((fen) => allFenKeys.add(fen))
 
     const result: {
       fen: string
       comment?: string
       suffixAnnotation?: string
+      glyph?: string
     }[] = []
 
     for (const fen of allFenKeys) {
       const commentContent = this._comments[fen]
       const suffixAnnotation = this._suffixes[fen]
+      const glyph = this._glyphs[fen]
 
       const entry: {
         fen: string
         comment?: string
         suffixAnnotation?: string
+        glyph?: string
       } = {
         fen: fen,
       }
@@ -2711,6 +2757,10 @@ export class Chess {
 
       if (suffixAnnotation !== undefined) {
         entry.suffixAnnotation = suffixAnnotation
+      }
+
+      if (glyph !== undefined) {
+        entry.glyph = glyph
       }
 
       result.push(entry)
@@ -2746,6 +2796,35 @@ export class Chess {
     const key = fen || this.fen()
     const old = this._suffixes[key]
     delete this._suffixes[key]
+    return old
+  }
+
+  /**
+   * Get the glyph for the given position (or current one).
+   */
+  public getGlyph(fen?: string): Glyph | undefined {
+    const key = fen ?? this.fen()
+    return this._glyphs[key]
+  }
+
+  /**
+   * Set or overwrite the glyph for the given position (or current).
+   * Throws if the glyph isn't one of the allowed GLYPH_LIST values.
+   */
+  public setGlyph(glyph: Glyph, fen?: string): void {
+    if (!GLYPH_LIST.includes(glyph)) {
+      throw new Error(`Invalid glyph: ${glyph}`)
+    }
+    this._glyphs[fen || this.fen()] = glyph
+  }
+
+  /**
+   * Remove the glyph for the given position (or current).
+   */
+  public removeGlyph(fen?: string): Glyph | undefined {
+    const key = fen || this.fen()
+    const old = this._glyphs[key]
+    delete this._glyphs[key]
     return old
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -96,24 +96,24 @@ export const SUFFIX_LIST = ['!', '?', '!!', '!?', '?!', '??'] as const
 export type Suffix = (typeof SUFFIX_LIST)[number]
 
 export const GLYPH_MAP = {
-  '$7': '□', // Only move
-  '$22': '⨀', // Zugzwang
-  '$10': '=', // Equal position
-  '$13': '∞', // Unclear position
-  '$14': '⩲', // White is slightly better
-  '$15': '⩱', // Black is slightly better
-  '$16': '±', // White is better
-  '$17': '∓', // Black is better
-  '$18': '+−', // White is winning
-  '$19': '-+', // Black is winning
-  '$146': 'N', // Novelty
-  '$32': '↑↑', // Development
-  '$36': '↑', // Initiative
-  '$40': '→', // Attack
-  '$132': '⇆', // Counterplay
-  '$138': '⊕', // Time trouble
-  '$44': '=∞', // With compensation
-  '$140': '∆', // With the idea
+  $7: '□', // Only move
+  $22: '⨀', // Zugzwang
+  $10: '=', // Equal position
+  $13: '∞', // Unclear position
+  $14: '⩲', // White is slightly better
+  $15: '⩱', // Black is slightly better
+  $16: '±', // White is better
+  $17: '∓', // Black is better
+  $18: '+−', // White is winning
+  $19: '-+', // Black is winning
+  $146: 'N', // Novelty
+  $32: '↑↑', // Development
+  $36: '↑', // Initiative
+  $40: '→', // Attack
+  $132: '⇆', // Counterplay
+  $138: '⊕', // Time trouble
+  $44: '=∞', // With compensation
+  $140: '∆', // With the idea
 } as const
 
 export const GLYPH_LIST = Object.values(GLYPH_MAP)

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -2286,9 +2286,9 @@ export class Chess {
             this._suffixes[this.fen()] = suffixAnnotation as Suffix
           }
 
-          // Store NAGs directly as numbers
+          // Store NAGs
           if (node.nags && node.nags.length > 0) {
-            this._nags[this.fen()] = node.nags.map((nag) => parseInt(nag, 10))
+            this._nags[this.fen()] = node.nags
           }
         }
       }
@@ -2722,7 +2722,7 @@ export class Chess {
     fen: string
     comment?: string
     suffixAnnotation?: string
-    nags?: NAG[]
+    nags: NAG[]
   }[] {
     this._pruneComments()
 
@@ -2735,7 +2735,7 @@ export class Chess {
       fen: string
       comment?: string
       suffixAnnotation?: string
-      nags?: NAG[]
+      nags: NAG[]
     }[] = []
 
     for (const fen of allFenKeys) {
@@ -2747,9 +2747,10 @@ export class Chess {
         fen: string
         comment?: string
         suffixAnnotation?: string
-        nags?: NAG[]
+        nags: NAG[]
       } = {
         fen: fen,
+        nags: nags ?? [],
       }
 
       if (commentContent !== undefined) {
@@ -2758,10 +2759,6 @@ export class Chess {
 
       if (suffixAnnotation !== undefined) {
         entry.suffixAnnotation = suffixAnnotation
-      }
-
-      if (nags !== undefined && nags.length > 0) {
-        entry.nags = nags
       }
 
       result.push(entry)
@@ -2803,9 +2800,9 @@ export class Chess {
   /**
    * Get the NAGs for the given position (or current one).
    */
-  public getNags(fen?: string): NAG[] | undefined {
+  public getNags(fen?: string): NAG[] {
     const key = fen ?? this.fen()
-    return this._nags[key]
+    return this._nags[key] ?? []
   }
 
   /**
@@ -2835,9 +2832,9 @@ export class Chess {
    * Remove all NAGs for the given position (or current).
    * Returns the removed NAGs.
    */
-  public removeNags(fen?: string): NAG[] | undefined {
+  public removeNags(fen?: string): NAG[] {
     const key = fen || this.fen()
-    const old = this._nags[key]
+    const old = this._nags[key] ?? []
     delete this._nags[key]
     return old
   }

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,7 +1,7 @@
 export type Node = {
   move?: string
   suffixAnnotation?: string
-  nags: string[]
+  nags: number[]
   comment?: string
   variations: Node[]
 }

--- a/src/pgn.peggy
+++ b/src/pgn.peggy
@@ -87,7 +87,7 @@ suffixAnnotation "suffix annotation"
 	= $[!?] |1..2|
       
 nag "NAG"
-	= _ '$' nag:$[0-9]+ { return nag }
+	= _ '$' nag:$[0-9]+ { return parseInt(nag, 10) }
 
 comment
 	= braceComment / restOfLineComment


### PR DESCRIPTION
## Changes Summary

### Previous Implementation (Glyph-based)
- Stored annotations as text symbols (e.g., `'±'`, `'∞'`)
- Only one glyph per position
- Used string keys like `$14`, `$16` in mapping
- Limited to predefined glyph symbols

### New Implementation (NAG-based)
- Stores annotations as numeric NAG codes (e.g., `16`, `13`)
- **Supports multiple NAGs per position** (stored as `NAG[]`)
- Uses numeric keys directly (e.g., `14`, `16`)
- Provides utility function to convert NAGs to glyphs