### PR TITLE
Fix: Pawns on edge ranks should have no chess.moves()

### DIFF
--- a/__tests__/regression.test.ts
+++ b/__tests__/regression.test.ts
@@ -29,6 +29,15 @@ describe('Regression Tests', () => {
     expect(chess.moves().join(' ')).toBe('Kd2 Ke2 Kxf2 Kf1 Kd1')
   })
 
+  it('Github Issue ##577 - pawn on edge rank should have no moves', () => {
+    const chess = new Chess()
+    chess.clear()
+    chess.put({ type: 'k', color: 'w' }, 'e1')
+    chess.put({ type: 'k', color: 'b' }, 'e8')
+    chess.put({ type: 'p', color: 'w' }, 'h8')
+    expect(chess.moves({ square: 'h8', verbose: true })).toEqual([])
+  })
+
   it('Github Issue #85 (white) - SetUp and FEN should be accepted in loadPgn', () => {
     const chess = new Chess()
     const pgn = [

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -1568,6 +1568,7 @@ export class Chess {
       let to: number
       if (type === PAWN) {
         if (forPiece && forPiece !== type) continue
+        if (rank(from) === RANK_1 || rank(from) === RANK_8) continue
 
         // single square, non-capturing
         to = from + PAWN_OFFSETS[us][0]


### PR DESCRIPTION
Closes #577 

Pawn on H8 throws a BigInt error when asked about `chess.moves({ square: 'h8' })`

```
TypeError: Cannot mix BigInt and other types, use explicit conversions
    at Chess._movePiece (/app/node_modules/src/chess.ts:1737:24)
    at Chess._makeMove (/app/node_modules/src/chess.ts:1764:10)
    at Chess._moveToSan (/app/node_modules/src/chess.ts:2279:10)
    at new Move (/app/node_modules/src/chess.ts:160:35)
    at /app/node_modules/src/chess.ts:1452:34
    at Array.map (<anonymous>)
    at Chess.moves (/app/node_modules/src/chess.ts:1452:20)
```